### PR TITLE
Run tests on CI.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Racket
+        run: |
+          sudo add-apt-repository ppa:plt/racket
+          sudo apt install xvfb racket
+      - name: Run Tests
+        run: |
+          xvfb-run raco test .


### PR DESCRIPTION
This enables Github Actions on this repo. Redex somehow relies on gtk properly initialized on linux, so `xvfb` is used to provide a temporary x-server during the execution.

It also complains that `grammar.rkt` is missing but i guess that's `mir/grammar.rkt` so i just fixed it.