### PR TITLE
Edit README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 # a-mir-formality
 
-This repository aims to be a complete, authoratative formal model of the Rust MIR. At present, however, it is an incomplete, experimental model thereof. Presuming these experiments bear fruit, the intention is to bring this model to Rust as an RFC and develop it as an official part of the language definition.
+This repository aims to be a complete, authoritative formal model of the [Rust MIR](https://rustc-dev-guide.rust-lang.org/mir/index.html).
+At present, however, it is an incomplete, experimental model thereof.
+Presuming these experiments bear fruit, the intention is to bring this model into Rust as an RFC
+and develop it as an official part of the language definition.
 
 ## Tool
 
-For the time being, the model is implemented in [PLT Redex](https://redex.racket-lang.org/). PLT Redex was chosen because it is ridiculously accessible and fun to use. It lets you write down type system rules and operational semantics in a notation that is very similar to what is commonly used in published papers and then execute them; you can also write collections of unit tests and fuzz your model by generating test programs automatically. The hope is that PLT Redex will prove to be a sufficiently accessible tool that many Rust contributors will be able to understand, play with, and extend the model.
+For the time being, the model is implemented in [PLT Redex](https://redex.racket-lang.org/).
+PLT Redex was chosen because it is ridiculously accessible and fun to use.
+It lets you write down type system rules and operational semantics in a notation that is very similar to what is commonly used in published papers and then execute them;
+you can also write collections of unit tests and fuzz your model by generating test programs automatically. The hope is that PLT Redex will prove to be a sufficiently accessible tool that many Rust contributors will be able to understand, play with, and extend the model.
 
-One downside of PLT Redex is that it doesn't scale naturally to performing proofs. We may choose to port the model to another system at some point, or maintain multiple variants.
+One downside of PLT Redex is that it doesn't scale naturally to performing proofs.
+We may choose to port the model to another system at some point, or maintain multiple variants.
 
-## Structure of the repository
-
-
-
+<!-- TODO -->
+<!-- ## Structure of the repository -->

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # a-mir-formality
 
-This repository aims to be a complete, authoritative formal model of the [Rust MIR](https://rustc-dev-guide.rust-lang.org/mir/index.html).
-At present, however, it is an incomplete, experimental model thereof.
+This repository is an early-stage experimental project that aims to be a complete, authoritative formal model of the [Rust MIR](https://rustc-dev-guide.rust-lang.org/mir/index.html).
 Presuming these experiments bear fruit, the intention is to bring this model into Rust as an RFC
 and develop it as an official part of the language definition.
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,12 @@ and develop it as an official part of the language definition.
 
 For the time being, the model is implemented in [PLT Redex](https://redex.racket-lang.org/).
 PLT Redex was chosen because it is ridiculously accessible and fun to use.
-It lets you write down type system rules and operational semantics in a notation that is very similar to what is commonly used in published papers and then execute them;
-you can also write collections of unit tests and fuzz your model by generating test programs automatically. The hope is that PLT Redex will prove to be a sufficiently accessible tool that many Rust contributors will be able to understand, play with, and extend the model.
+It lets you write down type system rules and operational semantics and then execute them,
+using a notation that is very similar to what is commonly used in published papers.
+You can also write collections of unit tests and fuzz your model by generating test programs automatically.
+
+The hope is that PLT Redex will prove to be a sufficiently accessible tool
+that many Rust contributors will be able to understand, play with, and extend the model.
 
 One downside of PLT Redex is that it doesn't scale naturally to performing proofs.
 We may choose to port the model to another system at some point, or maintain multiple variants.


### PR DESCRIPTION
Rewrite a few sentences, and makes minor changes throughout. Put the repository structure section in a TODO comment.

The large diff is from splitting the paragraphs into multiple lines along semantic lines, roughly one
sentence per line. (Also aims to be less than 100 characters per line.) I've always found this to be a best practice in technical documentation under version control.