### PR TITLE
Replace some code snippets with anchors

### DIFF
--- a/book/src/closer-look-decl.md
+++ b/book/src/closer-look-decl.md
@@ -23,17 +23,9 @@ where `item{1,2,3}` are either structs/enums (`AdtDecl`), traits (`TraitDecl`), 
 Let's look more closely at one of those kinds of items.
 A trait declaration looks like this:
 
-```scheme
-  (TraitDecl := (TraitId TraitContents))
-  (TraitContents := (trait KindedVarIds WhereClauses TraitItems))
-  ...
-  (WhereClauses := (WhereClause ...))
-  (WhereClause :=
-               (ForAll KindedVarIds WhereClause)
-               (Implemented TraitRef)
-               )
+```scheme,ignore
+{{#include ../../src/decl/grammar.rkt:Traits}}
 ```
-<span class="caption">[Source](https://github.com/nikomatsakis/a-mir-formality/blob/47eceea34b5f56a55d781acc73dca86c996b15c5/src/decl/grammar.rkt#L26-L27)</span>
 
 Here:
 

--- a/book/src/closer-look-decl.md
+++ b/book/src/closer-look-decl.md
@@ -11,13 +11,9 @@ that adds new stuff to `formality-ty`:
 
 For example, a set of crates looks like this:
 
-```scheme
- (CrateDecls := (CrateDecl ...))
-  (CrateDecl := (CrateId CrateContents))
-  (CrateContents := (crate (CrateItemDecl ...)))
-  (CrateItemDecl := AdtDecl TraitDecl TraitImplDecl)
+```scheme,ignore
+{{#include ../../src/decl/grammar.rkt:Crates}}
 ```
-<span class="caption">[Source](https://github.com/nikomatsakis/a-mir-formality/blob/47eceea34b5f56a55d781acc73dca86c996b15c5/src/decl/grammar.rkt#L7-L10)</span>
 
 Basically a crate `a` is represented as a list of items like `(a (crate (item1 item2 item3)))`
 where `item{1,2,3}` are either structs/enums (`AdtDecl`), traits (`TraitDecl`), or impls (`TraitImplDecl`).

--- a/book/src/closer-look-ty.md
+++ b/book/src/closer-look-ty.md
@@ -113,42 +113,17 @@ The resulting output is a substitution that maps `A`, `X`, and `Y` to the follow
 ### Predicates
 
 `formality-ty` also defines the core predicates used to define Rust semantics.
-The current definition is as follows ([source](https://github.com/nikomatsakis/a-mir-formality/blob/47eceea34b5f56a55d781acc73dca86c996b15c5/src/ty/grammar.rkt#L121-L130)):
+The current definition is as follows:
 
-```scheme
-(Predicate :=
-           ; `TraitRef` is (fully) implemented.
-           (Implemented TraitRef)
-           ; an impl exists for `TraitRef`; this *by itself* doesn't mean
-           ; that `TraitRef` is implemented, as the supertraits may not
-           ; have impls.
-           (HasImpl TraitRef)
-           ; the given type or lifetime is well-formed.
-           (WellFormed (ParameterKind Parameter))
-           )
+```scheme,ignore
+{{#include ../../src/ty/grammar.rkt:Predicates}}
 ```
 
 These core predicates are then used to define a richer vocabulary of goals (things that can be proven)
-and various kinds of "clauses" (things that are assumed to be true, axioms)
-([source](https://github.com/nikomatsakis/a-mir-formality/blob/47eceea34b5f56a55d781acc73dca86c996b15c5/src/ty/grammar.rkt#L136-L143)):
+and various kinds of "clauses" (things that are assumed to be true, axioms):
 
-```scheme
-  (Goals = (Goal ...))
-  (Goal :=
-        Predicate
-        (Equate Term Term)
-        (All Goals)
-        (Any Goals)
-        (Implies Hypotheses Goal)
-        (Quantifier KindedVarIds Goal)
-        )
-
-  ((Hypotheses Clauses Invariants) := (Clause ...))
-  ((Hypothesis Clause Invariant) :=
-                                 Predicate
-                                 (Implies Goals Predicate)
-                                 (ForAll KindedVarIds Clause)
-                                 )
+```scheme,ignore
+{{#include ../../src/logic/grammar.rkt:GoalsAndHypotheses}}
 ```
 
 Importantly, the *types layer* defines a solver that gives semantics to all the "meta" parts of goals and clauses -- e.g., it defines what it means to prove `(All (G1 G2))` (prove both `G1` and `G2`, duh). But it doesn't have any rules for what it means to prove the *core* predicates true -- so it could never prove `(Implemented (Debug ((! T))))`. Those rules all come from the declaration layer and are given to the types layer as part of the "environment".

--- a/src/decl/grammar.rkt
+++ b/src/decl/grammar.rkt
@@ -29,6 +29,7 @@
   (FieldDecls ::= (FieldDecl ...))
   (FieldDecl ::= (FieldId Ty))
 
+  ;; ANCHOR:Traits
   ;; TraitDecl -- trait Foo { ... }
   ;;
   ;; Unlike in Rust, the `KindedVarIds` here always include with `(TyKind Self)` explicitly.
@@ -56,6 +57,7 @@
                #;(Outlives (Parameter : Lt))
                #;(ProjectionEq TraitRef :: (AssociatedTyId Substitution) = Ty)
                )
+  ;; ANCHOR_END:Traits
 
   ;; Identifiers -- these are all equivalent, but we give them fresh names to help
   ;; clarify their purpose

--- a/src/decl/grammar.rkt
+++ b/src/decl/grammar.rkt
@@ -10,11 +10,13 @@
 (define-extended-language formality-decl formality-ty
   (DeclProgram ::= (CrateDecls CrateId))
 
+  ;; ANCHOR:Crates
   ;; Crate declarations
   (CrateDecls ::= (CrateDecl ...))
   (CrateDecl ::= (CrateId CrateContents))
   (CrateContents ::= (crate (CrateItemDecl ...)))
   (CrateItemDecl ::= AdtDecl TraitDecl TraitImplDecl)
+  ;; ANCHOR_END:Crates
 
   ;; AdtDecl -- struct/enum/union declarations
   (AdtDecl ::= (AdtId AdtContents))

--- a/src/logic/grammar.rkt
+++ b/src/logic/grammar.rkt
@@ -48,6 +48,7 @@
   ;; `Predicate` -- the atomic items that we can prove
   (Predicates ::= (Predicate ...))
 
+  ;; ANCHOR:GoalsAndHypotheses
   ;; `Goal` -- things we can prove. These consists of predicates
   ;; joined by various forms of logical operators that are built
   ;; into the proving system (see `cosld-solve.rkt`).
@@ -71,7 +72,8 @@
               (Implies Goals Predicate)
               (ForAll KindedVarIds Clause)
               )
-
+  ;; ANCHOR_END:GoalsAndHypotheses
+  
   ;; `Invariants` -- things which must be true or the type system has some bugs.
   ;; A rather restricted form of clause.
   (Invariants ::= (Invariant ...))

--- a/src/ty/grammar.rkt
+++ b/src/ty/grammar.rkt
@@ -26,6 +26,7 @@
   ;; Overridden from formality-logic.
   (Parameter ::= Ty Lt)
 
+  ;; ANCHOR:Predicates
   ;; `Predicate` -- the atomic items that we can prove
   ;;
   ;; Overridden from formality-logic.
@@ -39,6 +40,7 @@
              ; the given type or lifetime is well-formed.
              (WellFormed (ParameterKind Parameter))
              )
+  ;; ANCHOR_END:Predicates
 
   ;; Ty -- Rust types
   ;;


### PR DESCRIPTION
These anchors should help us keep the book and code in sync, especially since we are hoping to develop the model and the book simultaneously.

Note: one tradeoff when using these anchors is that we can't cleanup up the code for presentation in the docs (by removing comments, or "snipping" pieces of code).