### PR TITLE
Add special handling for the Copy trait

### DIFF
--- a/src/decl/decl-ok.rkt
+++ b/src/decl/decl-ok.rkt
@@ -196,6 +196,7 @@
    (where (AdtKind KindedVarIds_adt _ AdtVariants) (item-with-id CrateDecls AdtId))
    (where/error ((ParameterKind_adt VarId_adt) ...) KindedVarIds_adt)
    (where/error Ty_adt (TyRigid AdtId (VarId_adt ...)))
+   (where/error ((VariantId ((FieldId Ty_field) ...)) ...) AdtVariants)
    ]
 
   [; Base case: this is not a special item, or it has no special rules: return empty list.

--- a/src/decl/decl-ok.rkt
+++ b/src/decl/decl-ok.rkt
@@ -12,9 +12,9 @@
   ;; Given a set of crates and the decl for the current crate,
   ;; generate the goal that proves all declarations in the current crate are
   ;; "ok". Other crates are assumed to be "ok".
-  crate-ok-goal : CrateDecls CrateDecl -> Goal
+  crate-ok-goal : CrateDecls_cs CrateDecl_c -> Goal
 
-  #:pre (in? CrateDecl CrateDecls)
+  #:pre (in? CrateDecl_c CrateDecls_cs)
 
   [(crate-ok-goal CrateDecls (CrateId (crate (CrateItemDecl ...))))
    (All (Goal_regular ... Goal_lang-item ... ...))

--- a/src/decl/test/copy.rkt
+++ b/src/decl/test/copy.rkt
@@ -1,0 +1,83 @@
+#lang racket
+(require redex/reduction-semantics
+         "../decl-to-clause.rkt"
+         "../decl-ok.rkt"
+         "../grammar.rkt"
+         "../prove.rkt"
+         "../../util.rkt")
+
+;; Test the special rules for impls of the Copy trait.
+
+(module+ test
+  (redex-let*
+   formality-decl
+
+   ;; Test for that `impl Copy for i32` is permitted.
+
+   ((; trait rust:Copy { _: Foo }
+     TraitDecl_Copy (term (rust:Copy (trait ((TyKind Self)) () ()))))
+
+    (; impl rust:Copy for i32 { }
+     TraitImplDecl (term (impl () (rust:Copy ((scalar-ty i32))) () ())))
+
+    (; the crate has the struct, the trait, and the impl
+     CrateDecl (term (TheCrate (crate (TraitDecl_Copy
+                                       TraitImplDecl
+                                       )))))
+
+    (; create the Env for checking things in this crate
+     Env (term (env-for-crate-decl CrateDecl)))
+    )
+
+   (traced '()
+           (decl:test-can-prove
+            Env
+            (crate-ok-goal (CrateDecl) CrateDecl)
+            ))
+   )
+
+  (redex-let*
+   formality-decl
+
+   ;; Test for that `struct Foo { } struct Bar { f: Foo } impl Copy for Bar` is not permitted
+   ;; because `Foo: Copy` does not hold.
+
+   ((; trait rust:Copy { }
+     TraitDecl_Copy (term (rust:Copy (trait ((TyKind Self)) () ()))))
+
+    (; struct Foo { }
+     AdtDecl_Foo (term (Foo (struct
+                              () ; no generic parameters
+                              () ; no where clauses
+                              ((Foo ())) ; the 1 variant (named `Foo`)
+                              ))))
+
+    (; struct Bar { _: Foo }
+     AdtDecl_Bar (term (Bar (struct
+                              () ; no generic parameters
+                              () ; no where clauses
+                              ((Bar ((f (TyRigid Foo ()))
+                                     ))) ; the 1 variant (named `Foo`)
+                              ))))
+
+    (; impl rust:Copy for Bar { }
+     TraitImplDecl (term (impl () (rust:Copy ((TyRigid Bar ()))) () ())))
+
+    (; the crate has the struct, the trait, and the impl
+     CrateDecl (term (TheCrate (crate (TraitDecl_Copy
+                                       AdtDecl_Foo
+                                       AdtDecl_Bar
+                                       TraitImplDecl
+                                       )))))
+
+    (; create the Env for checking things in this crate
+     Env (term (env-for-crate-decl CrateDecl)))
+    )
+
+   (traced '()
+           (decl:test-cannot-prove
+            Env
+            (crate-ok-goal (CrateDecl) CrateDecl)
+            ))
+   )
+  )


### PR DESCRIPTION
This finishes the implementation from yesterday's walkthrough, adding a missing where clause and fixing the #:precondition.
Now, both tests in `decl/test/copy.rkt` pass.
I hope it's okay to open a PR for this. :smile: 