### PR TITLE
Rusty where clauses

### DIFF
--- a/book/src/closer-look-decl.md
+++ b/book/src/closer-look-decl.md
@@ -49,7 +49,7 @@ would be represented as
 (Foo (trait ; KindedVarIds -- the generics:
             ((type Self) (type T))
             ; where clauses, including supertraits:
-            ((is-implemented (Ord (T))) (is-implemented (Bar (Self))))
+            ((T : Ord()) (Self : Bar()))
             ; trait items, empty list:
             ()
             ))

--- a/docs/blog/2022-05-12.mdx
+++ b/docs/blog/2022-05-12.mdx
@@ -292,7 +292,7 @@ would be represented as
 (Foo (trait ; KindedVarIds -- the generics:
             ((type Self) (type T))
             ; where clauses, including supertraits:
-            ((is-implemented (Ord (T))) (is-implemented (Bar (Self))))
+            ((T : Ord()) (Self : Bar()))
             ; trait items, empty list:
             ()
             ))

--- a/docs/docs/how-formality-works/closer-look-decl.md
+++ b/docs/docs/how-formality-works/closer-look-decl.md
@@ -53,7 +53,7 @@ would be represented as
 (Foo (trait ; KindedVarIds -- the generics:
             ((type Self) (type T))
             ; where clauses, including supertraits:
-            ((is-implemented (Ord (T))) (is-implemented (Bar (Self))))
+            ((T : Ord()) (Self : Bar()))
             ; trait items, empty list:
             ()
             ))

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -13,18 +13,19 @@ How to build, test, and run a-mir-formality:
 * You can use [DrRacket](https://docs.racket-lang.org/drracket/), or you can use VSCode. We recommend the following VSCode extensions:
     * [Magic Racket](https://marketplace.visualstudio.com/items?itemName=evzen-wybitul.magic-racket) to give a Racket mode that supports most LSP operations decently well
     * [Rainbow brackets](https://marketplace.visualstudio.com/items?itemName=2gua.rainbow-brackets) is highly recommended to help sort out `()`
+    * The [Unicode Math](https://marketplace.visualstudio.com/items?itemName=studykit.unicode-math) or [Unicode Latex](https://marketplace.visualstudio.com/items?itemName=oijaz.unicode-latex) extensions are useful for inserting characters like `∀`.
 
 # Debugging tips
 
 ## Run racket manually for better stacktraces
 
-When you use `raco test`, you often get stacktraces that are not very helpful. You can do better by running racket manually with the `-lerrortrace` flag, which adds some runtime overhead but tracks more information. This command runs raco with error trace enabled:
+When you use `raco test`, you often get stacktraces that are not very helpful. You can do better by running racket manually with the `-l errortrace` flag, which adds some runtime overhead but tracks more information. The easiest way to do this is to use [the `test` script](https://github.com/nikomatsakis/a-mir-formality/blob/main/test) and give it the name of some `rkt` file, e.g. `src/decl/test/copy.rkt`. This will run the tests found in the `test` submodule within that file.
 
 ```bash
-racket -l errortrace -l raco -- test src/decl/test/copy.rkt
+./test src/decl/test/copy.rkt
 ```
 
-Alternatively, *this* command runs the tests found in the `test` submodule of `src/decl/test/copy.rkt` without using `raco`:
+This will expand to running `racket` with a command like this:
 
 ```bash
 racket -l errortrace -l racket/base -e '(require (submod "src/decl/test/copy.rkt" test))' 

--- a/src/decl/decl-ok.rkt
+++ b/src/decl/decl-ok.rkt
@@ -47,7 +47,7 @@
    (where/error ((VariantId ((FieldId Ty) ...)) ...) AdtVariants)
    (where/error Goal_wf (∀ KindedVarIds
                            (implies
-                            ((well-formed KindedVarId) ... WhereClause ...)
+                            ((well-formed KindedVarId) ... (where-clause->hypothesis WhereClause) ...)
                             (&& ((well-formed (type Ty)) ... ...)))))
    ]
 
@@ -58,7 +58,7 @@
    ;; we require that all the trait-item WF goals are met.
    (crate-item-ok-goal _ (TraitId (trait KindedVarIds (WhereClause ...) (TraitItem ...))))
    (∀ KindedVarIds
-      (implies ((well-formed KindedVarId) ... WhereClause ...)
+      (implies ((well-formed KindedVarId) ... (where-clause->hypothesis WhereClause) ...)
                (&& (Goal_trait-item ...))))
 
    (where/error (Goal_trait-item ...) ((trait-item-ok-goal TraitItem) ...))
@@ -79,7 +79,7 @@
         ; ...all inputs are WF...
         (well-formed (ParameterKind_trait Parameter_trait)) ...
         ; ...where-clauses are satisfied...
-        WhereClause_impl ...)
+        (where-clause->hypothesis WhereClause_impl) ...)
        (; ... then the trait must be implemented
         is-implemented (TraitId (Parameter_trait ...)))))
 
@@ -99,7 +99,7 @@
        (; assuming all generic parameters are WF...
         (well-formed KindedVarId) ...
         ; ...where-clauses are satisfied...
-        WhereClause ...)
+        (where-clause->hypothesis WhereClause) ...)
        (; ... then the trait must be implemented
         well-formed (type Ty))))
 

--- a/src/decl/test/basic-consts.rkt
+++ b/src/decl/test/basic-consts.rkt
@@ -17,7 +17,7 @@
    formality-decl
 
    ((TraitDecl (term (Debug (trait ((type Self)) () ()))))
-    (AdtDecl_Foo (term (Foo (struct ((type T)) ((is-implemented (Debug (T)))) ((Foo ()))))))
+    (AdtDecl_Foo (term (Foo (struct ((type T)) ((T : Debug())) ((Foo ()))))))
     (ConstDecl_Malformed (term (Malformed (const ((type T)) () (rigid-ty Foo (T))))))
     (CrateDecl (term (TheCrate (crate (TraitDecl AdtDecl_Foo ConstDecl_Malformed)))))
     (Env (term (env-for-crate-decl CrateDecl)))

--- a/src/decl/test/coinductive/issue-43784.rkt
+++ b/src/decl/test/coinductive/issue-43784.rkt
@@ -14,19 +14,19 @@
      AdtDecl_Foo (term (Foo (struct () () ((struct-variant ()))))))
 
     (; trait Partial: Copy { }
-     TraitDecl_Partial (term (Partial (trait ((type Self)) ((is-implemented (Copy (Self)))) ()))))
+     TraitDecl_Partial (term (Partial (trait ((type Self)) ((Self : Copy())) ()))))
 
     (; trait Complete: Partial { }
-     TraitDecl_Complete (term (Complete (trait ((type Self)) ((is-implemented (Partial (Self)))) ()))))
+     TraitDecl_Complete (term (Complete (trait ((type Self)) ((Self : Partial())) ()))))
 
     (; impl<T> Partial for T where T: Complete {}
-     TraitImplDecl_Partial (term (impl ((type T)) (Partial (T)) ((is-implemented (Complete (T)))) ())))
+     TraitImplDecl_Partial (term (impl ((type T)) (Partial (T)) ((T : Complete())) ())))
 
     (; impl<T> Complete for T {}
      TraitImplDecl_CompleteA (term (impl ((type T)) (Complete (T)) () ())))
 
     (; impl<T: Partial> Complete for T {}
-     TraitImplDecl_CompleteB (term (impl ((type T)) (Complete (T)) ((is-implemented (Partial (T)))) ())))
+     TraitImplDecl_CompleteB (term (impl ((type T)) (Complete (T)) ((T : Partial())) ())))
 
     (; crate A { ... }
      CrateDecl_A (term (A (crate (AdtDecl_Foo

--- a/src/decl/test/coinductive/magic-issue-xxx.rkt
+++ b/src/decl/test/coinductive/magic-issue-xxx.rkt
@@ -18,13 +18,13 @@
      Ty_Foo (term (rigid-ty Foo ())))
 
     (; trait Magic: Copy { }
-     TraitDecl_Magic (term (Magic (trait ((type Self)) ((is-implemented (Copy (Self)))) ()))))
+     TraitDecl_Magic (term (Magic (trait ((type Self)) ((Self : Copy())) ()))))
 
     (; trait Copy { }
      TraitDecl_Copy (term (Copy (trait ((type Self)) () ()))))
 
     (; impl<T> Magic for T where T: Magic { }
-     TraitImplDecl_Magic (term (impl ((type T)) (Magic (T)) ((is-implemented (Magic (T)))) ())))
+     TraitImplDecl_Magic (term (impl ((type T)) (Magic (T)) ((T : Magic())) ())))
 
     (; crate TheCrate { ... }
      CrateDecl (term (TheCrate (crate (TraitDecl_Magic TraitDecl_Copy TraitImplDecl_Magic)))))
@@ -65,13 +65,13 @@
      Ty_Foo (term (rigid-ty Foo ())))
 
     (; trait Magic: Copy { }
-     TraitDecl_Magic (term (Magic (trait ((type Self)) ((is-implemented (Copy (Self)))) ()))))
+     TraitDecl_Magic (term (Magic (trait ((type Self)) ((Self : Copy())) ()))))
 
     (; trait Copy: Magic { }
-     TraitDecl_Copy (term (Copy (trait ((type Self)) ((is-implemented (Magic (Self)))) ()))))
+     TraitDecl_Copy (term (Copy (trait ((type Self)) ((Self : Magic())) ()))))
 
     (; impl<T> Magic for T where T: Magic { }
-     TraitImplDecl_Magic (term (impl ((type T)) (Magic (T)) ((is-implemented (Magic (T)))) ())))
+     TraitImplDecl_Magic (term (impl ((type T)) (Magic (T)) ((T : Magic())) ())))
 
     (; crate TheCrate { ... }
      CrateDecl (term (TheCrate (crate (TraitDecl_Magic TraitDecl_Copy TraitImplDecl_Magic)))))
@@ -117,13 +117,13 @@
      Ty_Bar (term (rigid-ty Bar ())))
 
     (; trait Magic: Copy { }
-     TraitDecl_Magic (term (Magic (trait ((type Self)) ((is-implemented (Copy (Self)))) ()))))
+     TraitDecl_Magic (term (Magic (trait ((type Self)) ((Self : Copy())) ()))))
 
     (; trait Copy { }
      TraitDecl_Copy (term (Copy (trait ((type Self)) () ()))))
 
     (; impl<T> Magic for T where T: Magic { }
-     TraitImplDecl_Magic (term (impl ((type T)) (Magic (T)) ((is-implemented (Magic (T)))) ())))
+     TraitImplDecl_Magic (term (impl ((type T)) (Magic (T)) ((T : Magic())) ())))
 
     (; impl Copy for Foo { }
      TraitImplDecl_Copy (term (impl () (Copy (Ty_Foo)) () ())))

--- a/src/decl/test/drop.rkt
+++ b/src/decl/test/drop.rkt
@@ -84,7 +84,7 @@
      TraitDecl_Drop (term (rust:Drop (trait ((type Self)) () ()))))
 
     (; impl<U> rust:Drop for Foo<U> where U: Debug { } //~ ERROR
-     TraitImplDecl (term (impl ((type U)) (rust:Drop ((rigid-ty Foo (U)))) ((is-implemented (Debug (U)))) ())))
+     TraitImplDecl (term (impl ((type U)) (rust:Drop ((rigid-ty Foo (U)))) ((U : Debug())) ())))
 
     (; the crate has the struct, the trait, and the impl
      CrateDecl (term (TheCrate (crate (AdtDecl_Foo
@@ -146,7 +146,7 @@
    ;; the predicates on the struct.
 
    ((; struct Foo<T> where T: Ord { }
-     AdtDecl_Foo (term (Foo (struct ((type T)) ((is-implemented (Ord (T))))
+     AdtDecl_Foo (term (Foo (struct ((type T)) ((T : Ord()))
                               ((Foo ())) ; the 1 variant (named `Foo`)
                               ))))
 
@@ -157,13 +157,13 @@
      TraitDecl_Eq (term (Eq (trait ((type Self)) () ()))))
 
     (; trait Ord: Eq { }
-     TraitDecl_Ord (term (Ord (trait ((type Self)) ((is-implemented (Eq (Self)))) ()))))
+     TraitDecl_Ord (term (Ord (trait ((type Self)) ((Self : Eq())) ()))))
 
     (; impl<U> rust:Drop for Foo<U> where T: Ord + Eq { }
      TraitImplDecl (term (impl ((type U))
                                (rust:Drop ((rigid-ty Foo (U))))
-                               ((is-implemented (Ord (U)))
-                                (is-implemented (Eq (U)))
+                               ((U : Ord())
+                                (U : Eq())
                                 )
                                ())))
 

--- a/src/decl/test/multi-crate.rkt
+++ b/src/decl/test/multi-crate.rkt
@@ -31,8 +31,8 @@
      ;;
      CrateDecl_B (redex-let*
                   formality-decl
-                  ((TraitDecl_WithDebug (term (WithDebug (trait ((type Self) (type T)) ((is-implemented (Debug (T)))) ()))))
-                   (AdtDecl_Foo (term (Foo (struct ((type T)) ((is-implemented (Debug (T)))) ((Foo ()))))))
+                  ((TraitDecl_WithDebug (term (WithDebug (trait ((type Self) (type T)) ((T : Debug())) ()))))
+                   (AdtDecl_Foo (term (Foo (struct ((type T)) ((T : Debug())) ((Foo ()))))))
                    (TraitImplDecl (term (impl ((type T)) (WithDebug ((rigid-ty Foo (T)) T)) () ())))
                    )
                   (term (CrateB (crate (TraitDecl_WithDebug AdtDecl_Foo TraitImplDecl))))))
@@ -71,7 +71,7 @@
 
    (redex-let*
     formality-decl
-    ;; Crate C cannot prove `∀<T> { If (well-formed(Foo<T>) { is-implemented(Foo<T>: Debug) } }`
+    ;; Crate C cannot prove `∀<T> { If (well-formed(Foo<T>) { is-implemented(T: Debug) } }`
     ((Goal_C_ImpliedBound (term (∀ ((type T))
                                    (implies ((well-formed (type (rigid-ty Foo (T))))
                                              (well-formed (type T)))

--- a/src/decl/test/supertraits.rkt
+++ b/src/decl/test/supertraits.rkt
@@ -15,7 +15,7 @@
    formality-decl
 
    ((TraitDecl_PartialEq (term (PartialEq (trait ((type Self)) () ()))))
-    (TraitDecl_Eq (term (Eq (trait ((type Self)) ((is-implemented (PartialEq (Self)))) ()))))
+    (TraitDecl_Eq (term (Eq (trait ((type Self)) ((Self : PartialEq())) ()))))
     (TraitDecl_Debug (term (Debug (trait ((type Self)) () ()))))
     (CrateDecl (term (TheCrate (crate (TraitDecl_PartialEq TraitDecl_Eq)))))
     (Env (term (env-for-crate-decl CrateDecl)))

--- a/src/logic/elaborate.rkt
+++ b/src/logic/elaborate.rkt
@@ -191,6 +191,8 @@
             (term ((∀ ((type T)) (is-implemented (Ord (T))))
                    (∀ ((type T)) (is-implemented (Eq (T))))
                    (∀ ((type T)) (is-implemented (PartialOrd (T))))
-                   (∀ ((type T)) (is-implemented (PartialEq (T))))))))
+                   (∀ ((type T)) (is-implemented (PartialEq (T)))))))
+
+           )
    )
   )

--- a/src/ty/grammar.rkt
+++ b/src/ty/grammar.rkt
@@ -65,7 +65,7 @@
   (WhereClauses ::= (WhereClause ...))
   (WhereClause ::=
                (∀ KindedVarIds WhereClause)
-               (is-implemented TraitRef)
+               (Ty : TraitId Parameters)
                (Parameter : Lt)
                (normalizes-to AliasTy Ty)
                )

--- a/src/ty/grammar.rkt
+++ b/src/ty/grammar.rkt
@@ -66,7 +66,7 @@
   (WhereClause ::=
                (∀ KindedVarIds WhereClause)
                (is-implemented TraitRef)
-               (outlives (Parameter : Lt))
+               (Parameter : Lt)
                (normalizes-to AliasTy Ty)
                )
 

--- a/src/ty/grammar.rkt
+++ b/src/ty/grammar.rkt
@@ -67,7 +67,7 @@
                (∀ KindedVarIds WhereClause)
                (Ty : TraitId Parameters)
                (Parameter : Lt)
-               (normalizes-to AliasTy Ty)
+               (AliasTy == Ty)
                )
 
   ;; Ty -- Rust types

--- a/src/ty/parameters.rkt
+++ b/src/ty/parameters.rkt
@@ -39,8 +39,8 @@
 
   [(generics-for Env AdtId) (env-adt-generics Env AdtId)]
   [(generics-for Env ScalarId) (() ())]
-  [(generics-for Env (ref ())) (((TheLt (lifetime +)) (TheTy (type +))) ((outlives (TheTy : TheLt))))]
-  [(generics-for Env (ref (mut))) (((TheLt (lifetime +)) (TheTy (type =))) ((outlives (TheTy : TheLt))))]
+  [(generics-for Env (ref ())) (((TheLt (lifetime +)) (TheTy (type +))) ((TheTy : TheLt)))]
+  [(generics-for Env (ref (mut))) (((TheLt (lifetime +)) (TheTy (type =))) ((TheTy : TheLt)))]
 
   [; tuples are covariant in their elements P1...Pn
    (generics-for Env (tuple number_arity))

--- a/src/ty/test/test-alias-subtyping.rkt
+++ b/src/ty/test/test-alias-subtyping.rkt
@@ -94,7 +94,7 @@
             (term (ty:prove-scheme
                    Env
                    ((∀ ((lifetime A) (lifetime B))))
-                   ((outlives (A : B)))
+                   ((A : B))
                    ((item (& A TyUnit))
                     <=
                     (item (& B TyUnit))
@@ -112,8 +112,8 @@
             (term (ty:prove-scheme
                    Env
                    ((∀ ((lifetime A) (lifetime B))))
-                   ((outlives (A : B))
-                    (outlives (B : A))
+                   ((A : B)
+                    (B : A)
                     )
                    ((item (& A TyUnit))
                     <=
@@ -132,7 +132,7 @@
             (term (ty:prove-scheme
                    Env
                    ((∀ ((lifetime A) (lifetime B))))
-                   ((outlives (A : B)))
+                   ((A : B))
                    ((item (vec (& A TyUnit)))
                     <=
                     (item (vec (& B TyUnit)))

--- a/src/ty/test/test-alias-subtyping.rkt
+++ b/src/ty/test/test-alias-subtyping.rkt
@@ -75,8 +75,8 @@
             (term (ty:prove-scheme
                    Env
                    ((∀ ((type T) (type U))))
-                   ((normalizes-to (item T) (scalar-ty i32))
-                    (normalizes-to (item U) (scalar-ty i32)))
+                   (((item T) == (scalar-ty i32))
+                    ((item U) == (scalar-ty i32)))
                    ((item T)
                     <=
                     (item U)

--- a/src/ty/test/test-outlives.rkt
+++ b/src/ty/test/test-outlives.rkt
@@ -141,7 +141,7 @@
             (term (ty:prove-scheme
                    Env
                    ((∀ ((lifetime A) (lifetime B))))
-                   ((outlives (A : B)))
+                   ((A : B))
                    (A -outlives- B)
                    ))
             )
@@ -159,7 +159,7 @@
             (term (ty:prove-scheme
                    Env
                    ((∀ ((lifetime A) (lifetime B))))
-                   ((outlives (A : B))
+                   ((A : B)
                     )
                    (A == B)
                    ))
@@ -178,8 +178,8 @@
             (term (ty:prove-scheme
                    Env
                    ((∀ ((lifetime A) (lifetime B))))
-                   ((outlives (A : B))
-                    (outlives (B : A))
+                   ((A : B)
+                    (B : A)
                     )
                    (A == B)
                    ))

--- a/src/ty/test/test-subtyping.rkt
+++ b/src/ty/test/test-subtyping.rkt
@@ -40,23 +40,23 @@
 
    ; Cannot have an implication on the subtype side that doesn't appear on the supertype side
    (traced '()
-           (ty:test-cannot-prove Env ((∀ ((type T)) (implies ((is-implemented (NeverImpl (T)))) T))
+           (ty:test-cannot-prove Env ((∀ ((type T)) (implies ((T : NeverImpl ())) T))
                                       <=
                                       (∀ ((type T)) T)))
            )
 
    ; ...unless we can prove it.
    (traced '()
-           (ty:test-can-prove Env ((∀ ((type T)) (implies ((is-implemented (AlwaysImpl (T)))) T))
+           (ty:test-can-prove Env ((∀ ((type T)) (implies ((T : AlwaysImpl ())) T))
                                    <=
                                    (∀ ((type T)) T)))
            )
 
    ; OK if the implication is on both sides.
    (traced '()
-           (ty:test-can-prove Env ((∀ ((type T)) (implies ((is-implemented (NeverImpl (T)))) T))
+           (ty:test-can-prove Env ((∀ ((type T)) (implies ((T : NeverImpl ())) T))
                                    <=
-                                   (∀ ((type T)) (implies ((is-implemented (NeverImpl (T)))) T))))
+                                   (∀ ((type T)) (implies ((T : NeverImpl ())) T))))
            )
 
    ; OK if the implication is just on supertype side: that means that the consumer will prove it,
@@ -64,7 +64,7 @@
    (traced '()
            (ty:test-can-prove Env ((∀ ((type T)) T)
                                    <=
-                                   (∀ ((type T)) (implies ((is-implemented (NeverImpl (T)))) T))))
+                                   (∀ ((type T)) (implies ((T : NeverImpl ())) T))))
            )
 
    (test-match
@@ -146,10 +146,10 @@
                    Env
                    ((∀ ((type T)))
                     )
-                   ((is-implemented (Debug (T))))
+                   ((T : Debug()))
                    (T
                     <=
-                    (ensures T ((is-implemented (Debug (T)))))
+                    (ensures T ((T : Debug())))
                     )))))
 
    (; Test for ensures: we cannot add ensures for things we cannot prove
@@ -163,7 +163,7 @@
            ()
            (T
             <=
-            (ensures T ((is-implemented (Debug (T)))))
+            (ensures T ((T : Debug())))
             ))))
 
 
@@ -176,9 +176,9 @@
            ((∀ ((type T)))
             )
            ()
-           ((ensures T ((is-implemented (Debug (T)))))
+           ((ensures T ((T : Debug())))
             <=
-            (ensures T ((is-implemented (Debug (T)))))
+            (ensures T ((T : Debug())))
             ))))
 
    (; Test for implication in subtype
@@ -192,7 +192,7 @@
            ((∀ ((type T)))
             )
            ()
-           ((implies ((is-implemented (Debug (T)))) T)
+           ((implies ((T : Debug())) T)
             <=
             T
             ))))
@@ -208,8 +208,8 @@
            Env
            ((∀ ((type T)))
             )
-           ((is-implemented (Debug (T))))
-           ((implies ((is-implemented (Debug (T)))) T)
+           ((T : Debug()))
+           ((implies ((T : Debug())) T)
             <=
             T
             ))))
@@ -228,7 +228,7 @@
            ()
            (T
             <=
-            (implies ((is-implemented (Debug (T)))) T)
+            (implies ((T : Debug())) T)
             ))))
 
    (; Test for implication in supertype
@@ -244,7 +244,7 @@
            ()
            (U
             <=
-            (implies ((is-implemented (Debug (T)))) T)
+            (implies ((T : Debug())) T)
             ))))
 
    (; Test for implication on both sides
@@ -256,9 +256,9 @@
            ((∀ ((type T)))
             )
            ()
-           ((implies ((is-implemented (Debug (T)))) T)
+           ((implies ((T : Debug())) T)
             <=
-            (implies ((is-implemented (Debug (T)))) T)
+            (implies ((T : Debug())) T)
             ))))
 
    (; #25860 -- the buggy path we have today, where implied bounds

--- a/src/ty/test/test-subtyping.rkt
+++ b/src/ty/test/test-subtyping.rkt
@@ -295,7 +295,7 @@
                    ()
                    ((; fn foo<'a, 'b, T>(_: &'a &'b (), v: &'b T) -> &'a T { v }
                      ∀ ((lifetime A) (lifetime B))
-                       (implies ((outlives (B : A))) ; implied bound!
+                       (implies ((B : A)) ; implied bound!
                                 (fn ((& A (& B TyUnit)) (& B T)) (& A T))))
                     <=
                     (; fn(&'static &'x (), &'x T) -> &'static T
@@ -317,7 +317,7 @@
                    ()
                    ((; fn foo<'a, 'b, T>(_: &'a &'b (), v: &'b T) -> &'a T { v }
                      ∀ ((lifetime A) (lifetime B))
-                       (implies ((outlives (B : A))) ; implied bound!
+                       (implies ((B : A)) ; implied bound!
                                 (fn ((& A (& B TyUnit)) (& B T)) (& A T))))
                     <=
                     (; fn(&'x &'static (), &'static T) -> &'x T

--- a/src/ty/where-clauses.rkt
+++ b/src/ty/where-clauses.rkt
@@ -36,7 +36,7 @@
    (normalizes-to AliasTy Ty)
    ]
 
-  [(where-clause->goal (outlives (Parameter_a : Parameter_b)))
+  [(where-clause->goal (Parameter_a : Parameter_b))
    (Parameter_a -outlives- Parameter_b)
    ]
 

--- a/src/ty/where-clauses.rkt
+++ b/src/ty/where-clauses.rkt
@@ -32,7 +32,7 @@
    (is-implemented (TraitId (Ty_self Parameter ...)))
    ]
 
-  [(where-clause->goal (normalizes-to AliasTy Ty))
+  [(where-clause->goal (AliasTy == Ty))
    (normalizes-to AliasTy Ty)
    ]
 

--- a/src/ty/where-clauses.rkt
+++ b/src/ty/where-clauses.rkt
@@ -28,8 +28,8 @@
    (∀ KindedVarIds (where-clause->goal WhereClause))
    ]
 
-  [(where-clause->goal (is-implemented TraitRef))
-   (is-implemented TraitRef)
+  [(where-clause->goal (Ty_self : TraitId (Parameter ...)))
+   (is-implemented (TraitId (Ty_self Parameter ...)))
    ]
 
   [(where-clause->goal (normalizes-to AliasTy Ty))

--- a/test
+++ b/test
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ "$1" == "" ];
+then
+	echo "expected: test file.rkt"
+        exit 1
+fi
+
+racket -l errortrace -l racket/base -e '(require (submod "'$1'" test))'


### PR DESCRIPTION
Change the syntax of where-clauses to be more Rust-like, also detecting a bunch of places we failed to do the `where-clause->goal` transformation.