### PR TITLE
some more terminal naming fixes

### DIFF
--- a/book/src/closer-look-decl.md
+++ b/book/src/closer-look-decl.md
@@ -30,8 +30,8 @@ A trait declaration looks like this:
 Here:
 
 * `TraitId` is the name of the trait
-* `KindedVarIds` is a list of generic parameters like `((TyVar Self) (TyVar T))`.
-  Note that the `Self` parameter is made explicit. 
+* `KindedVarIds` is a list of generic parameters like `((type Self) (type T))`.
+  Note that the `Self` parameter is made explicit.
 * `WhereClauses` is a list of where-clauses, which are currently just `T: Foo` trait references
   (though potentially higher-ranked).
 * `TraitItems` are the contents of the trait, currently not used for anything.
@@ -95,7 +95,7 @@ and ultimately invokes this helper function, `crate-item-decl-rules`:
 ```
 <span class="caption">[Source](https://github.com/nikomatsakis/a-mir-formality/blob/47eceea34b5f56a55d781acc73dca86c996b15c5/src/decl/decl-to-clause.rkt#L57-L63)</span>
 
-`crate-item-decl-rules` takes 
+`crate-item-decl-rules` takes
 
 * the full set of crates `CrateDecls` and
 * the declaration of a single item `CrateItemDecl`
@@ -108,7 +108,7 @@ We'll cover the invariants later.
 <!-- move/copy description of metafunctions to ty chapter -->
 Metafunctions are basically a gigantic match statement.
 They consist of a series of clauses,
-each of which begins with a "pattern match" against the arguments. 
+each of which begins with a "pattern match" against the arguments.
 
 To see how it works, let's look at the case for an `impl` from that section.
 To begin with, here is the comment explaining what we aim to do:
@@ -148,7 +148,7 @@ The function this is part of  -- this says we will produce one global clause
 This final result is allowed to refer to variables defined on the following lines, shown below.
 A `(where/error <pattern> <value>)` clause is effectively just `let <pattern> = <value>`, in Rust terms;
 the `/error` part means "if this pattern doesn't match, generate an error".
-You can also write `(where <pattern> <value>)`, but that means that if the pattern doesn't match, 
+You can also write `(where <pattern> <value>)`, but that means that if the pattern doesn't match,
 the metafunction should to see if the next rule works.
 
 The impl code begins by pattern matching against the `TraitRef` that the impl is implementing
@@ -212,7 +212,7 @@ Here is the source, I'll leave puzzling it out as an exercise to the reader:
 
 ### Generating the "ok goals" for a crate
 
-In addition to "clauses", there is also a function `crate-ok-goal` 
+In addition to "clauses", there is also a function `crate-ok-goal`
 that generate goals for each crate item in a given crate:
 
 ```scheme
@@ -249,7 +249,7 @@ Here is the rule for impls:
 In short, an `impl` is well-formed if the trait is fully implemented.
 We'll look at the definition of *implemented* in more detail in [the next section](./case-study.md),
 but for now it suffices to say that a trait is implemented if
-(a) it has an impl and 
+(a) it has an impl and
 (b) all of its where-clauses are satisfied.
-Since we know there is an impl (we're checking it right now!) this is equivalent to saying 
+Since we know there is an impl (we're checking it right now!) this is equivalent to saying
 "all of the trait's where clauses are satisfied".

--- a/book/src/closer-look-ty.md
+++ b/book/src/closer-look-ty.md
@@ -10,7 +10,7 @@ The current definition of types looks like this:
 (define-language formality-ty
   ...
   (Ty :=
-      (TyApply TyName Parameters) ; Application type
+      (rigid-ty TyName Parameters) ; Application type
       VarId                       ; Bound or existential (inference) variable
       (! VarId)                   ; Universal (placeholder) variable
       )
@@ -47,9 +47,9 @@ Let's see some examples:
     * `T` is used when the generic has yet to be substituted, e.g., as part of a declaration.
     * `(! T)` is used as a placeholder to "any type `T`".
 * A type like `Vec<T>` in Rust would be represented therefore as:
-    * `(TyApply Vec (T))`, in a declaration; or,
-    * `(TyApply Vec ((! T)))` when checking it.
-* A scalar type like `i32` is represented as `(TyApply i32 ())`.
+    * `(rigid-ty Vec (T))`, in a declaration; or,
+    * `(rigid-ty Vec ((! T)))` when checking it.
+* A scalar type like `i32` is represented as `(rigid-ty i32 ())`.
 
 As I said, this defintion of types is woefully incomplete. I expect it to eventually include:
 
@@ -97,8 +97,8 @@ Invoking `most-general-unifier` like so:
 
 ```scheme
 (most-general-unifier Env_2 ((A X)
-                             (X (TyApply Vec (Y)))
-                             (Y (TyApply i32 ()))))
+                             (X (rigid-ty Vec (Y)))
+                             (Y (rigid-ty i32 ()))))
 ```
 
 <!-- maybe: `A == X`,  `X == Vec<Y>`, and `Y == i32` -->

--- a/docs/docs/how-formality-works/closer-look-decl.md
+++ b/docs/docs/how-formality-works/closer-look-decl.md
@@ -34,8 +34,8 @@ A trait declaration looks like this:
 Here:
 
 * `TraitId` is the name of the trait
-* `KindedVarIds` is a list of generic parameters like `((TyVar Self) (TyVar T))`.
-  Note that the `Self` parameter is made explicit. 
+* `KindedVarIds` is a list of generic parameters like `((type Self) (type T))`.
+  Note that the `Self` parameter is made explicit.
 * `WhereClauses` is a list of where-clauses, which are currently just `T: Foo` trait references
   (though potentially higher-ranked).
 * `TraitItems` are the contents of the trait, currently not used for anything.
@@ -99,7 +99,7 @@ and ultimately invokes this helper function, `crate-item-decl-rules`:
 ```
 <span class="caption">[Source](https://github.com/nikomatsakis/a-mir-formality/blob/47eceea34b5f56a55d781acc73dca86c996b15c5/src/decl/decl-to-clause.rkt#L57-L63)</span>
 
-`crate-item-decl-rules` takes 
+`crate-item-decl-rules` takes
 
 * the full set of crates `CrateDecls` and
 * the declaration of a single item `CrateItemDecl`
@@ -112,7 +112,7 @@ We'll cover the invariants later.
 <!-- move/copy description of metafunctions to ty chapter -->
 Metafunctions are basically a gigantic match statement.
 They consist of a series of clauses,
-each of which begins with a "pattern match" against the arguments. 
+each of which begins with a "pattern match" against the arguments.
 
 To see how it works, let's look at the case for an `impl` from that section.
 To begin with, here is the comment explaining what we aim to do:
@@ -152,7 +152,7 @@ The function this is part of  -- this says we will produce one global clause
 This final result is allowed to refer to variables defined on the following lines, shown below.
 A `(where/error <pattern> <value>)` clause is effectively just `let <pattern> = <value>`, in Rust terms;
 the `/error` part means "if this pattern doesn't match, generate an error".
-You can also write `(where <pattern> <value>)`, but that means that if the pattern doesn't match, 
+You can also write `(where <pattern> <value>)`, but that means that if the pattern doesn't match,
 the metafunction should to see if the next rule works.
 
 The impl code begins by pattern matching against the `TraitRef` that the impl is implementing
@@ -216,7 +216,7 @@ Here is the source, I'll leave puzzling it out as an exercise to the reader:
 
 ### Generating the "ok goals" for a crate
 
-In addition to "clauses", there is also a function `crate-ok-goal` 
+In addition to "clauses", there is also a function `crate-ok-goal`
 that generate goals for each crate item in a given crate:
 
 ```scheme
@@ -253,7 +253,7 @@ Here is the rule for impls:
 In short, an `impl` is well-formed if the trait is fully implemented.
 We'll look at the definition of *implemented* in more detail in [the next section](../what-formality-can-do/case-study),
 but for now it suffices to say that a trait is implemented if
-(a) it has an impl and 
+(a) it has an impl and
 (b) all of its where-clauses are satisfied.
-Since we know there is an impl (we're checking it right now!) this is equivalent to saying 
+Since we know there is an impl (we're checking it right now!) this is equivalent to saying
 "all of the trait's where clauses are satisfied".

--- a/docs/docs/how-formality-works/closer-look-ty.md
+++ b/docs/docs/how-formality-works/closer-look-ty.md
@@ -13,9 +13,9 @@ The current definition of types looks like this:
 (define-language formality-ty
   ...
   (Ty :=
-      (TyApply TyName Parameters) ; Application type
-      VarId                       ; Bound or existential (inference) variable
-      (! VarId)                   ; Universal (placeholder) variable
+      (rigid-ty TyName Parameters) ; Application type
+      VarId                        ; Bound or existential (inference) variable
+      (! VarId)                    ; Universal (placeholder) variable
       )
   (TyName :=
           AdtId           ; enum/struct/union
@@ -50,9 +50,9 @@ Let's see some examples:
     * `T` is used when the generic has yet to be substituted, e.g., as part of a declaration.
     * `(! T)` is used as a placeholder to "any type `T`".
 * A type like `Vec<T>` in Rust would be represented therefore as:
-    * `(TyApply Vec (T))`, in a declaration; or,
-    * `(TyApply Vec ((! T)))` when checking it.
-* A scalar type like `i32` is represented as `(TyApply i32 ())`.
+    * `(rigid-ty Vec (T))`, in a declaration; or,
+    * `(rigid-ty Vec ((! T)))` when checking it.
+* A scalar type like `i32` is represented as `(rigid-ty i32 ())`.
 
 As I said, this defintion of types is woefully incomplete. I expect it to eventually include:
 
@@ -100,8 +100,8 @@ Invoking `most-general-unifier` like so:
 
 ```scheme
 (most-general-unifier Env_2 ((A X)
-                             (X (TyApply Vec (Y)))
-                             (Y (TyApply i32 ()))))
+                             (X (rigid-ty Vec (Y)))
+                             (Y (rigid-ty i32 ()))))
 ```
 
 <!-- maybe: `A == X`,  `X == Vec<Y>`, and `Y == i32` -->

--- a/src/decl/decl-to-clause.rkt
+++ b/src/decl/decl-to-clause.rkt
@@ -274,7 +274,7 @@
   ((default-rules ())
    (((well-formed (type (scalar-ty i32)))
      (well-formed (type (scalar-ty u32)))
-     (well-formed (type TyUnit))
+     (well-formed (type unit-ty))
      )
     ())
    )

--- a/src/decl/grammar.rkt
+++ b/src/decl/grammar.rkt
@@ -4,7 +4,7 @@
          trait-decl-id
          item-with-id
          scalar-ty
-         TyUnit
+         unit-ty
          )
 
 (define-extended-language formality-decl formality-ty

--- a/src/ty/grammar.rkt
+++ b/src/ty/grammar.rkt
@@ -181,7 +181,7 @@
   )
 
 (define-term
-  TyUnit
+  unit-ty
   (rigid-ty (tuple 0) ())
   )
 

--- a/src/ty/test/test-alias-subtyping.rkt
+++ b/src/ty/test/test-alias-subtyping.rkt
@@ -95,9 +95,9 @@
                    Env
                    ((∀ ((lifetime A) (lifetime B))))
                    ((outlives (A : B)))
-                   ((item (& A TyUnit))
+                   ((item (& A unit-ty))
                     <=
-                    (item (& B TyUnit))
+                    (item (& B unit-ty))
                     )
                    )
                   )
@@ -115,9 +115,9 @@
                    ((outlives (A : B))
                     (outlives (B : A))
                     )
-                   ((item (& A TyUnit))
+                   ((item (& A unit-ty))
                     <=
-                    (item (& B TyUnit))
+                    (item (& B unit-ty))
                     )
                    )
                   )
@@ -133,9 +133,9 @@
                    Env
                    ((∀ ((lifetime A) (lifetime B))))
                    ((outlives (A : B)))
-                   ((item (vec (& A TyUnit)))
+                   ((item (vec (& A unit-ty)))
                     <=
-                    (item (vec (& B TyUnit)))
+                    (item (vec (& B unit-ty)))
                     )
                    )
                   )

--- a/src/ty/test/test-outlives.rkt
+++ b/src/ty/test/test-outlives.rkt
@@ -74,7 +74,7 @@
                    Env
                    ()
                    ()
-                   ((∀ ((lifetime A)) (rigid-ty (fn-ptr "" 1) ((rigid-ty (ref ()) (A (scalar-ty u32))) TyUnit)))
+                   ((∀ ((lifetime A)) (rigid-ty (fn-ptr "" 1) ((rigid-ty (ref ()) (A (scalar-ty u32))) unit-ty)))
                     -outlives-
                     static)
                    ))

--- a/src/ty/test/test-subtyping.rkt
+++ b/src/ty/test/test-subtyping.rkt
@@ -132,9 +132,9 @@
            ((∀ ((type T)))
             )
            ()
-           ((rigid-ty (fn-ptr "" 1) (T TyUnit)) ; fn(T)
+           ((rigid-ty (fn-ptr "" 1) (T unit-ty)) ; fn(T)
             <=
-            (∀ ((type T)) (fn (T) TyUnit)) ; forall<T> fn(T)
+            (∀ ((type T)) (fn (T) unit-ty)) ; forall<T> fn(T)
             ))))
 
    (traced '()
@@ -273,10 +273,10 @@
            ()
            ((; fn foo<'a, 'b, T>(_: &'a &'b (), v: &'b T) -> &'a T { v }
              ∀ ((lifetime A) (lifetime B))
-               (fn ((& A (& B TyUnit)) (& B T)) (& A T)))
+               (fn ((& A (& B unit-ty)) (& B T)) (& A T)))
             <=
             (; fn(&'static &'x (), &'x T) -> &'static T
-             fn ((& static (& X TyUnit)) (& X T)) (& static T))
+             fn ((& static (& X unit-ty)) (& X T)) (& static T))
             )
            )
           )
@@ -296,10 +296,10 @@
                    ((; fn foo<'a, 'b, T>(_: &'a &'b (), v: &'b T) -> &'a T { v }
                      ∀ ((lifetime A) (lifetime B))
                        (implies ((B : A)) ; implied bound!
-                                (fn ((& A (& B TyUnit)) (& B T)) (& A T))))
+                                (fn ((& A (& B unit-ty)) (& B T)) (& A T))))
                     <=
                     (; fn(&'static &'x (), &'x T) -> &'static T
-                     fn ((& static (& X TyUnit)) (& X T)) (& static T))
+                     fn ((& static (& X unit-ty)) (& X T)) (& static T))
                     )
                    )
                   )
@@ -318,10 +318,10 @@
                    ((; fn foo<'a, 'b, T>(_: &'a &'b (), v: &'b T) -> &'a T { v }
                      ∀ ((lifetime A) (lifetime B))
                        (implies ((B : A)) ; implied bound!
-                                (fn ((& A (& B TyUnit)) (& B T)) (& A T))))
+                                (fn ((& A (& B unit-ty)) (& B T)) (& A T))))
                     <=
                     (; fn(&'x &'static (), &'static T) -> &'x T
-                     fn ((& X (& static TyUnit)) (& static T)) (& X T))
+                     fn ((& X (& static unit-ty)) (& static T)) (& X T))
                     )
                    )
                   )


### PR DESCRIPTION
Some additional cleanup after #18.

* Fixed `TyVar` -> `type` and `TyApply` -> `rigid-ty` in documentation
  * some remaining uses in blog/2022-50-12.mdx but I left it alone since it looks like a historical document
* Renamed `TyUnit` -> `unit-ty`, because even though it is a term definition rather than a primitive terminal constant, it is closer to a constant than a variable (and this also matches the use of other similar metafunctions like `(vec T)`). I thought about removing the `-ty`, but I think this is a non-context-sensitive macro expansion and I wouldn't want other uses of `unit` outside the type grammar to get expanded.
* Some trailing whitespace and missing final newline issues were auto-fixed by my vscode config in the files I touched. I can disable this behavior or roll it back if people care.