### PR TITLE
Make `Place` grammar recursive

### DIFF
--- a/src/mir/grammar.rkt
+++ b/src/mir/grammar.rkt
@@ -50,7 +50,14 @@
 
   (Constant ::= number)
 
-  (Place ::= (LocalId Projections))
+  (Place ::=
+         LocalId
+         (* Place)
+         (field Place FieldId)
+         (index Place LocalId)
+         (downcast Place VariantId)
+         )
+
   (Projections ::= (Projection ...))
   (Projection ::=
               *

--- a/src/mir/projection.rkt
+++ b/src/mir/projection.rkt
@@ -3,21 +3,21 @@
 (provide (all-defined-out))
 
 (define-metafunction formality-mir
+  apply-projection : Place Projection -> Place
+
+  [(apply-projection Place *) (* Place)]
+  [(apply-projection Place (field FieldId)) (field Place FieldId)]
+  [(apply-projection Place (index LocalId)) (index Place LocalId)]
+  [(apply-projection Place (downcast VariantId)) (downcast Place VariantId)]
+  )
+
+(define-metafunction formality-mir
   apply-projections : Place Projections -> Place
 
   [(apply-projections Place ()) Place]
 
-  [(apply-projections Place (* Projection ...))
-   (apply-projections (* Place) (Projection ...))]
-
-  [(apply-projections Place ((field FieldId) Projection ...))
-   (apply-projections (field Place FieldId) (Projection ...))]
-
-  [(apply-projections Place ((index LocalId) Projection ...))
-   (apply-projections (index Place LocalId) (Projection ...))]
-
-  [(apply-projections Place ((downcast VariantId) Projection ...))
-   (apply-projections (downcast Place VariantId) (Projection ...))]
+  [(apply-projections Place (Projection_hd Projection_tl ...))
+   (apply-projections (apply-projection Place Projection_hd) (Projection_tl ...))]
   )
 
 (define-metafunction formality-mir

--- a/src/mir/projection.rkt
+++ b/src/mir/projection.rkt
@@ -1,0 +1,43 @@
+#lang racket
+(require redex "grammar.rkt")
+(provide (all-defined-out))
+
+(define-metafunction formality-mir
+  apply-projections : Place Projections -> Place
+
+  [(apply-projections Place ()) Place]
+
+  [(apply-projections Place (* Projection ...))
+   (apply-projections (* Place) (Projection ...))]
+
+  [(apply-projections Place ((field FieldId) Projection ...))
+   (apply-projections (field Place FieldId) (Projection ...))]
+
+  [(apply-projections Place ((index LocalId) Projection ...))
+   (apply-projections (index Place LocalId) (Projection ...))]
+
+  [(apply-projections Place ((downcast VariantId) Projection ...))
+   (apply-projections (downcast Place VariantId) (Projection ...))]
+  )
+
+(define-metafunction formality-mir
+  unpack-projections : Place -> (LocalId Projections)
+
+  [(unpack-projections LocalId) (LocalId ())]
+
+  [(unpack-projections (* Place))
+   (LocalId (Projection ... *))
+   (where (LocalId (Projection ...)) (unpack-projections Place))]
+
+  [(unpack-projections (field Place FieldId))
+   (LocalId (Projection ... (field FieldId)))
+   (where (LocalId (Projection ...)) (unpack-projections Place))]
+
+  [(unpack-projections (index Place LocalId))
+   (LocalId (Projection ... (index LocalId)))
+   (where (LocalId (Projection ...)) (unpack-projections Place))]
+
+  [(unpack-projections (downcast Place VariantId))
+   (LocalId (Projection ... (downcast VariantId)))
+   (where (LocalId (Projection ...)) (unpack-projections Place))]
+  )


### PR DESCRIPTION
This changes the `Place` grammar to directly include projection operations instead of being a pair of a local and a list of projections, so that e.g. you get things like `(field (* x) i)` instead of  `(x (* (field i)))`. This is both easier to read, as well as (presumably) easier to define judgments over.

For applications that do prefer the list-of-projections form, the `apply-projections` and `unpack-projections` functions are provided to convert back and forth.