### PR TITLE
implement a basic version of the coherence check

### DIFF
--- a/src/decl/grammar.rkt
+++ b/src/decl/grammar.rkt
@@ -10,6 +10,8 @@
          adt-with-id
          crate-decls
          instantiate-bounds-clause
+         crate-defining-trait-with-id
+         crate-defining-adt-with-id
          )
 
 (define-extended-language formality-decl formality-ty
@@ -195,6 +197,18 @@
   )
 
 (define-metafunction formality-decl
+  ;; Find the id of the crate that defines `AdtId`.
+  crate-defining-adt-with-id : CrateDecls AdtId -> CrateId
+
+  [(crate-defining-adt-with-id CrateDecls AdtId)
+   CrateId
+
+   (where (_ ... CrateDecl _ ...) CrateDecls)
+   (where (CrateId (crate (_ ... (AdtKind AdtId _ where _ _) _ ...))) CrateDecl)
+   ]
+  )
+
+(define-metafunction formality-decl
   ;; Find the given trait amongst all the declared crates.
   trait-with-id : CrateDecls TraitId -> TraitDecl
 
@@ -203,6 +217,18 @@
 
    (where (_ ... CrateDecl _ ...) CrateDecls)
    (where (_ (crate (_ ... (trait TraitId KindedVarIds where WhereClauses TraitItems) _ ...))) CrateDecl)
+   ]
+  )
+
+(define-metafunction formality-decl
+  ;; Find the id of the crate that defines `TraitId`.
+  crate-defining-trait-with-id : CrateDecls TraitId -> CrateId
+
+  [(crate-defining-trait-with-id CrateDecls TraitId)
+   CrateId
+
+   (where (_ ... CrateDecl _ ...) CrateDecls)
+   (where (CrateId (crate (_ ... (trait TraitId _ where _ _) _ ...))) CrateDecl)
    ]
   )
 

--- a/src/mir/all-check.rkt
+++ b/src/mir/all-check.rkt
@@ -5,6 +5,7 @@
          "well-formed-mir.rkt"
          "unsafe-check.rkt"
          "borrow-check.rkt"
+         "coherence-orphan.rkt"
          "../decl/decl-ok.rkt"
          "../decl/decl-to-clause.rkt"
          "../decl/grammar.rkt"
@@ -62,6 +63,7 @@
 
   [; impl declarations
    (prove-crate-item-ok DeclProgram TraitImplDecl)
+   (✅-OrphanRules DeclProgram TraitImplDecl)
    ; FIXME -- need to check the impl items
    ----------------------------------------
    (✅-CrateItemDecl DeclProgram TraitImplDecl)

--- a/src/mir/coherence-orphan.rkt
+++ b/src/mir/coherence-orphan.rkt
@@ -1,0 +1,64 @@
+#lang racket
+(require redex/reduction-semantics
+         "grammar-extended.rkt"
+         "type-check-goal.rkt"
+         "well-formed-mir.rkt"
+         "unsafe-check.rkt"
+         "borrow-check.rkt"
+         "../decl/decl-ok.rkt"
+         "../decl/decl-to-clause.rkt"
+         "../decl/grammar.rkt"
+         "../logic/instantiate.rkt"
+         "prove-goal.rkt"
+         )
+(provide ✅-OrphanRules
+         )
+
+(define-judgment-form
+  formality-mir-extended
+
+  ;; The conditions under which an impl passes the orphan rules.
+
+  #:mode (✅-OrphanRules I I)
+  #:contract (✅-OrphanRules DeclProgram TraitImplDecl)
+
+  [(where/error (CrateDecls CrateId) DeclProgram)
+   (where/error (impl _ (TraitId _) where _ _) TraitImplDecl)
+   (where CrateId (crate-defining-trait-with-id CrateDecls TraitId))
+   ------------------------------- "orphan--trait-is-in-current-crate"
+   (✅-OrphanRules DeclProgram TraitImplDecl)]
+
+  [(where/error (impl KindedVarIds (_ (Parameter_self Parameter_other ...)) where WhereClauses _) TraitImplDecl)
+   (is-local-parameter DeclProgram Parameter_self)
+   ------------------------------- "orphan--self-is-local"
+   (✅-OrphanRules DeclProgram TraitImplDecl)]
+
+  ; FIXME there are more rules
+
+  )
+
+
+(define-judgment-form
+  formality-mir-extended
+
+  ;; The conditions under which an impl passes the orphan rules.
+
+  #:mode (is-local-parameter I I)
+  #:contract (is-local-parameter DeclProgram Parameter)
+
+  [------------------------------- "orphan--scalars-are-local-to-care"
+   (is-local-parameter (_ core) (rigid-ty ScalarId _))]
+
+  [------------------------------- "orphan--refs-are-local-to-core"
+   (is-local-parameter (_ core) (rigid-ty (ref _) _))]
+
+  [------------------------------- "orphan--fns-are-local-to-core"
+   (is-local-parameter (_ core) (rigid-ty (fn-ptr _ _) _))]
+
+  [(where CrateId (crate-defining-adt-with-id CrateDecls AdtId))
+   ------------------------------- "orphan--adts"
+   (is-local-parameter (CrateDecls CrateId) (rigid-ty AdtId _))]
+
+  ; FIXME -- there are more rules we could add
+
+  )

--- a/src/mir/prove-goal.rkt
+++ b/src/mir/prove-goal.rkt
@@ -19,7 +19,7 @@
   #:contract (prove-crate-item-ok DeclProgram CrateItemDecl)
 
   [(where/error Goal_ok (crate-item-ok-goal (crate-decls DeclProgram) CrateItemDecl))
-   (where/error (Goal_lang-ok ...) (lang-item-ok-goals (crate-decls DeclProgram) CrateItemDecl))
+   (where/error [Goal_lang-ok ...] (lang-item-ok-goals (crate-decls DeclProgram) CrateItemDecl))
    (prove-goal DeclProgram Goal_ok)
    (prove-goal DeclProgram Goal_lang-ok) ...
    ----------------------------------------
@@ -34,7 +34,7 @@
   #:contract (prove-goal DeclProgram Goal)
 
   [(where/error Env (env-for-decl-program DeclProgram))
-   (logic:prove-top-level-goal/cosld Env Goal Env)
+   (logic:prove-top-level-goal/cosld Env Goal Env_1)
    ----------------------------------------
    (prove-goal DeclProgram Goal)
    ]

--- a/src/mir/test/coherence-orphan.rkt
+++ b/src/mir/test/coherence-orphan.rkt
@@ -1,0 +1,71 @@
+#lang racket
+(require redex/reduction-semantics
+         "../all-check.rkt"
+         "../grammar.rkt"
+         "../../ty/grammar.rkt"
+         "../../ty/user-ty.rkt"
+         "../../util.rkt"
+         "../../decl/test/libcore.rkt"
+         )
+
+(module+ test
+  (redex-let*
+   formality-mir
+
+   [(TraitDecl_TraitA (term (trait TraitA[(type Self)] where [] {})))
+    (AdtDecl_StructA (term (struct StructA[] where [] [(StructA {})])))
+
+    ; the various impls one might write
+    (TraitImplDecl_AforA (term (impl[] (TraitA[(user-ty (StructA))]) where [] {})))
+    ]
+
+   (; both trait/struct in same crate
+    redex-let*
+    formality-mir
+    [(DeclProgram (term ([core-crate-decl
+                          (CrateA (crate [TraitDecl_TraitA AdtDecl_StructA TraitImplDecl_AforA]))
+                          ]
+                         CrateA)))]
+    (traced '()
+            (test-equal
+             (judgment-holds (✅-Program DeclProgram))
+             #t)))
+
+   (; trait/struct in parent crate, impl in child -- error
+    redex-let*
+    formality-mir
+    [(DeclProgram (term ([core-crate-decl
+                          (CrateA (crate [TraitDecl_TraitA AdtDecl_StructA]))
+                          (CrateB (crate [TraitImplDecl_AforA]))
+                          ]
+                         CrateB)))]
+    (traced '() (test-equal
+                 (judgment-holds (✅-Program DeclProgram))
+                 #f)))
+
+   (; trait in parent crate, struct/impl in child -- ok
+    redex-let*
+    formality-mir
+    [(DeclProgram (term ([core-crate-decl
+                          (CrateA (crate [TraitDecl_TraitA]))
+                          (CrateB (crate [AdtDecl_StructA TraitImplDecl_AforA]))
+                          ]
+                         CrateB)))]
+    (traced '() (test-equal
+                 (judgment-holds (✅-Program DeclProgram))
+                 #t)))
+
+   (; struct in parent crate, trait/impl in child -- ok
+    redex-let*
+    formality-mir
+    [(DeclProgram (term ([core-crate-decl
+                          (CrateA (crate [AdtDecl_StructA]))
+                          (CrateB (crate [TraitDecl_TraitA TraitImplDecl_AforA]))
+                          ]
+                         CrateB)))]
+    (traced '() (test-equal
+                 (judgment-holds (✅-Program DeclProgram))
+                 #t)))
+
+   )
+  )


### PR DESCRIPTION
Shows where the orphan rules can fit and implements a *very* simple version that permits an `impl` if the trait is local or the struct is a crate-local struct. 

cc https://github.com/nikomatsakis/a-mir-formality/issues/65