### PR TITLE
Use UserTy in impls and where clauses

### DIFF
--- a/src/decl/decl-ok/crate-item.rkt
+++ b/src/decl/decl-ok/crate-item.rkt
@@ -5,6 +5,7 @@
          "../feature-gate.rkt"
          "../../logic/env.rkt"
          "../../logic/grammar.rkt"
+         "../../ty/user-ty.rkt"
          "trait-item.rkt"
          "impl-item.rkt"
          "wf-where-clause.rkt"
@@ -82,7 +83,7 @@
    ;;
    ;; we require that the trait is implemented, given that all generics are WF,
    ;; all inputs are WF, and where-clauses are satisfied.
-   (crate-item-ok-goal CrateDecls (impl KindedVarIds_impl (TraitId (Parameter_trait ...)) where WhereClauses_impl (ImplItem ...)))
+   (crate-item-ok-goal CrateDecls (impl KindedVarIds_impl TraitId (UserParameter_trait ...) for UserTy where WhereClauses_impl (ImplItem ...)))
    (∀ KindedVarIds_impl
       (implies
        (; assuming all generic parameters are WF...
@@ -97,11 +98,12 @@
             Goal_item ...
             ))))
 
+   (where/error (Parameter_trait ...) ((user-ty UserTy) (user-parameter UserParameter_trait) ...))
    (where/error (trait TraitId ((ParameterKind_trait _) ...) where _ _) (trait-with-id CrateDecls TraitId))
    (where/error (KindedVarId_impl ...) KindedVarIds_impl)
    (where/error (WhereClause_impl ...) WhereClauses_impl)
    (where/error (Goal_item ...) ((impl-item-ok-goal CrateDecls
-                                                    (TraitId (Parameter_trait ...))
+                                                    TraitId (UserTy UserParameter_trait ...)
                                                     ImplItem) ...))
    ]
 

--- a/src/decl/decl-ok/lang-item.rkt
+++ b/src/decl/decl-ok/lang-item.rkt
@@ -4,6 +4,7 @@
          "../where-clauses.rkt"
          "../feature-gate.rkt"
          "../../logic/env.rkt"
+         "../../ty/user-ty.rkt"
          )
 (provide lang-item-ok-goals
          )
@@ -38,7 +39,7 @@
    ;
    ; when this goal is given to the solver, it would be rejected because `T: Eq` is not provable
    ; (we only know that `T: Debug`).
-   (lang-item-ok-goals CrateDecls (impl KindedVarIds_impl (rust:Drop (Ty_impl)) where (WhereClause_impl ...) _))
+   (lang-item-ok-goals CrateDecls (impl KindedVarIds_impl rust:Drop () for UserTy_impl where (WhereClause_impl ...) _))
    ((∀ KindedVarIds_adt
        (implies (where-clauses->hypotheses CrateDecls WhereClauses_adt)
                 (∃ KindedVarIds_impl
@@ -47,14 +48,14 @@
                         ))
                    ))))
 
-   (where (rigid-ty AdtId Parameters) Ty_impl)
+   (where (rigid-ty AdtId Parameters) (user-ty UserTy_impl))
    (where (AdtKind AdtId KindedVarIds_adt where WhereClauses_adt _) (adt-with-id CrateDecls AdtId))
    (where/error ((ParameterKind_adt VarId_adt) ...) KindedVarIds_adt)
    (where/error Ty_adt (rigid-ty AdtId (VarId_adt ...)))
    ]
 
   [; Impl of the Drop trait for something that is not an ADT -- always an error.
-   (lang-item-ok-goals CrateDecls (impl KindedVarIds_impl (rust:Drop (_ ...)) where WhereClauses_impl _))
+   (lang-item-ok-goals CrateDecls (impl KindedVarIds_impl rust:Drop () for _ where WhereClauses_impl _))
    ((|| ())) ; unprovable goal
    ]
 
@@ -79,7 +80,7 @@
    ;          (is-implemented (Vec<T>: Copy)))
    ;
    ; of course, in this case, it is not provable because `Vec<T>: Copy` is not true for any `T`.
-   (lang-item-ok-goals CrateDecls (impl KindedVarIds_impl (rust:Copy (Ty_impl)) where (WhereClause_impl ...) ()))
+   (lang-item-ok-goals CrateDecls (impl KindedVarIds_impl rust:Copy () for UserTy_impl where (WhereClause_impl ...) ()))
    ((∀ KindedVarIds_impl
        (implies ((where-clause->hypothesis CrateDecls WhereClause_impl) ...)
                 (∃ KindedVarIds_adt
@@ -88,7 +89,7 @@
                         )
                        )))))
 
-   (where (rigid-ty AdtId Parameters) Ty_impl)
+   (where (rigid-ty AdtId Parameters) (user-ty Ty_impl))
    (where (AdtKind AdtId KindedVarIds_adt where _ AdtVariants) (adt-with-id CrateDecls AdtId))
    (where/error ((ParameterKind_adt VarId_adt) ...) KindedVarIds_adt)
    (where/error Ty_adt (rigid-ty AdtId (VarId_adt ...)))

--- a/src/decl/decl-ok/trait-item.rkt
+++ b/src/decl/decl-ok/trait-item.rkt
@@ -49,7 +49,7 @@
 
    ; requirements for bound (`Sized`) to be wf:
    (where/error AliasTy (alias-ty (TraitId AssociatedTyId) (VarId_trait ... VarId ...)))
-   (where/error (WhereClause_bound ...) (instantiate-bounds-clause BoundsClause AliasTy))
+   (where/error (WhereClause_bound ...) (instantiate-bounds-clause BoundsClause (internal AliasTy)))
    (where/error (Goal_bound-wf ...) ((well-formed-where-clause-goal CrateDecls WhereClause_bound) ...))
    ]
   )

--- a/src/decl/decl-to-clause/impl-item.rkt
+++ b/src/decl/decl-to-clause/impl-item.rkt
@@ -4,6 +4,7 @@
          "../where-clauses.rkt"
          "../feature-gate.rkt"
          "../../logic/env.rkt"
+         "../../ty/user-ty.rkt"
          )
 (provide impl-item-decl-rules
          )
@@ -13,7 +14,7 @@
   ;;
   ;; * The clauses that hold in all crates due to this item
   ;; * The invariants that hold
-  impl-item-decl-rules : CrateDecls CrateId (impl KindedVarIds TraitRef where WhereClauses) ImplItem -> (Clauses Invariants)
+  impl-item-decl-rules : CrateDecls CrateId (impl KindedVarIds TraitId UserParameters for UserTy where WhereClauses) ImplItem -> (Clauses Invariants)
 
   [;; For a method declared in a trait: currently no logical rules are created.
    (impl-item-decl-rules CrateDecls CrateId _ FnDecl)
@@ -26,7 +27,7 @@
    ;; *
    (impl-item-decl-rules CrateDecls
                          CrateId
-                         (impl [KindedVarId_impl ...] (TraitId [Parameter_impl ...]) where WhereClauses_impl)
+                         (impl [KindedVarId_impl ...] TraitId (UserParameter_trait ...) for UserTy where WhereClauses_impl)
                          AssociatedTyValue)
    ([Clause_norm] [])
 
@@ -40,7 +41,8 @@
    (where/error [(_ VarId_trait) ...] KindedVarIds_trait)
 
    ; create the alias-ty being defined
-   (where/error AliasTy (alias-ty (TraitId AssociatedTyId) [Parameter_impl ... VarId_val ...]))
+   (where/error (Parameter_trait ...) ((user-ty UserTy) (user-parameter UserParameter_trait) ...))
+   (where/error AliasTy (alias-ty (TraitId AssociatedTyId) [Parameter_trait ... VarId_val ...]))
 
    (where/error Clause_norm
                 (∀ [KindedVarId_impl ... KindedVarId_val ...]

--- a/src/decl/decl-to-clause/trait-item.rkt
+++ b/src/decl/decl-to-clause/trait-item.rkt
@@ -51,7 +51,7 @@
    ;; (is-implemented Sized ((alias-ty (Iterator Item) (T)))) :-
    ;;     (well-formed (alias-ty (Iterator Item) (T)))
    ;; ```
-   (where/error [Clause_if-wf ...] (where-clauses->hypotheses CrateDecls (instantiate-bounds-clause BoundsClause_i AliasTy)))
+   (where/error [Clause_if-wf ...] (where-clauses->hypotheses CrateDecls (instantiate-bounds-clause BoundsClause_i (internal AliasTy))))
    (where/error [Invariant_bound ...] [(∀ (KindedVarId_t ... KindedVarId_i ...)
                                           (implies ((well-formed (type AliasTy))) Clause_if-wf)) ...])
 

--- a/src/decl/grammar.rkt
+++ b/src/decl/grammar.rkt
@@ -81,7 +81,7 @@
   ;; Trait impls
   ;;
   ;; Note that trait impls do not have names.
-  (TraitImplDecl ::= (impl KindedVarIds TraitRef where WhereClauses ImplItems))
+  (TraitImplDecl ::= (impl KindedVarIds TraitId UserParameters for UserTy where WhereClauses ImplItems))
 
   ;; Named statics
   (StaticDecl ::= (static StaticId KindedVarIds where WhereClauses : Ty = FnBody))
@@ -111,9 +111,10 @@
                )
   (WhereClauseAtoms ::= (WhereClauseAtom ...))
   (WhereClauseAtom ::=
-                   (Ty : TraitId Parameters) ; T: Debug
-                   (Parameter : Lt) ; T: 'a
-                   (AliasTy == Ty) ; <T as Iterator>::Item == u32
+                   (UserTy : TraitId UserParameters) ; T: Debug
+                   (UserTy : Lt) ; T: 'a
+                   (Lt >= Lt) ; a': 'b
+                   (UserAliasTy == UserTy) ; <T as Iterator>::Item == u32
                    )
 
   ;; Identifiers -- these are all equivalent, but we give them fresh names to help
@@ -137,7 +138,8 @@
          where WhereClauses #:refers-to (shadow VarId ...)
          TraitItems #:refers-to (shadow VarId ...))
   (impl ((ParameterKind VarId) ...)
-        TraitRef #:refers-to (shadow VarId ...)
+        TraitId UserParameters #:refers-to (shadow VarId ...)
+        for UserTy #:refers-to (shadow VarId ...)
         where WhereClauses #:refers-to (shadow VarId ...)
         ImplItems #:refers-to (shadow VarId ...))
   (const ConstId
@@ -235,9 +237,9 @@
 (define-metafunction formality-decl
   ;; Given a bound like `: Sized`, 'instantiates' to apply to a given type `T`,
   ;; yielding a where clause like `T: Sized`.
-  instantiate-bounds-clause : BoundsClause Parameter -> WhereClauses
+  instantiate-bounds-clause : BoundsClause UserParameter -> WhereClauses
 
-  [(instantiate-bounds-clause (: (ParameterKind VarId) WhereClauses) Parameter)
-   (apply-substitution ((VarId Parameter)) WhereClauses)
+  [(instantiate-bounds-clause (: (ParameterKind VarId) WhereClauses) UserParameter)
+   (apply-substitution ((VarId UserParameter)) WhereClauses)
    ]
   )

--- a/src/decl/test/assoc-type-values-gats-wf.rkt
+++ b/src/decl/test/assoc-type-values-gats-wf.rkt
@@ -35,7 +35,7 @@
 
     (; impl<T> Iterator for Lend<T> { type Item<'a> = &'a T where T : 'a; }
      TraitImplDecl_LendingIterator_for_Lend<T>
-     (term (impl((type T)) (LendingIterator ((user-ty (Lend T))))
+     (term (impl((type T)) LendingIterator () for (Lend T)
                 where ()
                 {
                  (type Item ((lifetime a)) = (user-ty (& a T))

--- a/src/decl/test/assoc-type-values-meet-trait-bounds.rkt
+++ b/src/decl/test/assoc-type-values-meet-trait-bounds.rkt
@@ -37,7 +37,7 @@
 
     (; impl<T: Sized> Iterator for MyIter<T> { type Item = T; }
      TraitImplDecl_Iterator_for_MyIter<T>_where_T:Sized
-     (term (impl ((type T)) (Iterator ((user-ty (MyIter T))))
+     (term (impl ((type T)) Iterator () for (MyIter T)
                  where ((T : rust:Sized ()))
                  {
                   (type Item () = T where ())
@@ -45,7 +45,7 @@
 
     (; impl<T: Sized> Iterator for MyIter<T> { type Item = T; }
      TraitImplDecl_Iterator_for_MyIter<T>_where_T:?Sized
-     (term (impl ((type T)) (Iterator ((user-ty (MyIter T))))
+     (term (impl ((type T)) Iterator() for (MyIter T)
                  where ()
                  {
                   (type Item () = T where ())

--- a/src/decl/test/assoc-type-values-normalize.rkt
+++ b/src/decl/test/assoc-type-values-normalize.rkt
@@ -23,7 +23,7 @@
 
     (; impl<T> Iterator for (T,) { type Item = Once; }
      TraitImplDecl_Iterator_for_Once<T>
-     (term (impl ((type T)) (Iterator ((user-ty (tuple T))))
+     (term (impl ((type T)) Iterator () for (tuple T)
                  where ()
                  {
                   (type Item () = (user-ty (Once T)) where ())
@@ -37,7 +37,7 @@
 
     (; impl<T> Copy for Once<T> where T: Copy { }
      TraitImplDecl_Copy_for_Once<T>
-     (term (impl[(type T)] (rust:Copy[(user-ty (Once T))])
+     (term (impl[(type T)] rust:Copy[] for (Once T)
                 where [(T : rust:Copy[])]
                 {})))
 

--- a/src/decl/test/assoc-type-values-wf.rkt
+++ b/src/decl/test/assoc-type-values-wf.rkt
@@ -31,7 +31,7 @@
 
     (; impl<T> Iterator for (T,) { type Item = MyIter<T>; }
      TraitImplDecl_Iterator_for_MyIter<T>_where_T:?Copy
-     (term (impl ((type T)) (Iterator ((user-ty (tuple T))))
+     (term (impl ((type T)) Iterator () for (tuple T)
                  where ()
                  {
                   (type Item () = (user-ty (MyIter T)) where ())

--- a/src/decl/test/basic-statics.rkt
+++ b/src/decl/test/basic-statics.rkt
@@ -38,7 +38,7 @@
     [(; static S: Foo;
       StaticDecl (term (static S () where () : (rigid-ty Foo ()) = dummy-body)))
      (; impl Send for Foo
-      TraitImplDecl_Sync (term (impl ((type T)) (rust:Sync ((rigid-ty Foo ()))) where () ())))
+      TraitImplDecl_Sync (term (impl ((type T)) rust:Sync () for (Foo) where () ())))
      (CrateDecl (term (TheCrate (crate (AdtDecl_Foo StaticDecl TraitImplDecl_Sync)))))
      ]
 

--- a/src/decl/test/basic.rkt
+++ b/src/decl/test/basic.rkt
@@ -15,7 +15,7 @@
    formality-decl
 
    ((TraitDecl (term (trait Debug ((type Self)) where () {})))
-    (TraitImplDecl (term (impl () (Debug ((user-ty i32))) where () {})))
+    (TraitImplDecl (term (impl () Debug () for i32 where () {})))
     (CrateDecl (term (TheCrate (crate (TraitDecl TraitImplDecl)))))
     )
 

--- a/src/decl/test/coinductive/issue-43784.rkt
+++ b/src/decl/test/coinductive/issue-43784.rkt
@@ -23,13 +23,13 @@
      TraitDecl_Complete (term (trait Complete ((type Self)) where ((Self : Partial())) ())))
 
     (; impl<T> Partial for T where T: Complete {}
-     TraitImplDecl_Partial (term (impl ((type T)) (Partial (T)) where ((T : Complete())) ())))
+     TraitImplDecl_Partial (term (impl ((type T)) Partial () for T where ((T : Complete())) ())))
 
     (; impl<T> Complete for T {}
-     TraitImplDecl_CompleteA (term (impl ((type T)) (Complete (T)) where () ())))
+     TraitImplDecl_CompleteA (term (impl ((type T)) Complete () for T where () ())))
 
     (; impl<T: Partial> Complete for T {}
-     TraitImplDecl_CompleteB (term (impl ((type T)) (Complete (T)) where ((T : Partial())) ())))
+     TraitImplDecl_CompleteB (term (impl ((type T)) Complete () for T where ((T : Partial())) ())))
 
     (; crate A { ... }
      CrateDecl_A (term (A (crate (AdtDecl_Foo

--- a/src/decl/test/coinductive/magic-issue-xxx.rkt
+++ b/src/decl/test/coinductive/magic-issue-xxx.rkt
@@ -26,7 +26,7 @@
      TraitDecl_Copy (term (trait Copy ((type Self)) where () ())))
 
     (; impl<T> Magic for T where T: Magic { }
-     TraitImplDecl_Magic (term (impl ((type T)) (Magic (T)) where ((T : Magic())) ())))
+     TraitImplDecl_Magic (term (impl ((type T)) Magic () for T where ((T : Magic())) ())))
 
     (; crate TheCrate { ... }
      CrateDecl (term (TheCrate (crate (TraitDecl_Magic TraitDecl_Copy TraitImplDecl_Magic)))))
@@ -73,7 +73,7 @@
      TraitDecl_Copy (term (trait Copy ((type Self)) where ((Self : Magic())) {})))
 
     (; impl<T> Magic for T where T: Magic { }
-     TraitImplDecl_Magic (term (impl ((type T)) (Magic (T)) where ((T : Magic())) {})))
+     TraitImplDecl_Magic (term (impl ((type T)) Magic () for T where ((T : Magic())) {})))
 
     (; crate TheCrate { ... }
      CrateDecl (term (TheCrate (crate (TraitDecl_Magic TraitDecl_Copy TraitImplDecl_Magic)))))
@@ -125,10 +125,10 @@
      TraitDecl_Copy (term (trait Copy ((type Self)) where () {})))
 
     (; impl<T> Magic for T where T: Magic { }
-     TraitImplDecl_Magic (term (impl ((type T)) (Magic (T)) where ((T : Magic())) {})))
+     TraitImplDecl_Magic (term (impl ((type T)) Magic () for T where ((T : Magic())) {})))
 
     (; impl Copy for Foo { }
-     TraitImplDecl_Copy (term (impl () (Copy (Ty_Foo)) where () {})))
+     TraitImplDecl_Copy (term (impl () Copy () for (Foo) where () {})))
 
     (; crate TheCrate { ... }
      CrateDecl (term (TheCrate (crate (TraitDecl_Magic TraitDecl_Copy TraitImplDecl_Magic)))))

--- a/src/decl/test/copy.rkt
+++ b/src/decl/test/copy.rkt
@@ -19,7 +19,7 @@
      TraitDecl_Copy (term (trait rust:Copy ((type Self)) where () ())))
 
     (; impl rust:Copy for i32 { }
-     TraitImplDecl (term (impl () (rust:Copy ((user-ty i32))) where () ())))
+     TraitImplDecl (term (impl () rust:Copy () for i32 where () ())))
 
     (; the crate has the struct, the trait, and the impl
      CrateDecl (term (TheCrate (crate (TraitDecl_Copy
@@ -59,7 +59,7 @@
                          )))
 
     (; impl rust:Copy for Bar { }
-     TraitImplDecl (term (impl () (rust:Copy ((rigid-ty Bar ()))) where () ())))
+     TraitImplDecl (term (impl () rust:Copy () for (Bar) where () ())))
 
     (; the crate has the struct, the trait, and the impl
      CrateDecl (term (TheCrate (crate (TraitDecl_Copy
@@ -78,7 +78,7 @@
    (redex-let*
     formality-decl
     [(; impl rust:Copy for Foo { }
-      TraitImplDecl_Foo (term (impl () (rust:Copy ((rigid-ty Foo ()))) where () ())))
+      TraitImplDecl_Foo (term (impl () rust:Copy () for (Foo) where () ())))
 
      (; the crate has the struct, the trait, and the impl
       CrateDecl_Pass (term (TheCrate (crate [TraitDecl_Copy

--- a/src/decl/test/drop.rkt
+++ b/src/decl/test/drop.rkt
@@ -19,7 +19,7 @@
      TraitDecl_Drop (term (trait rust:Drop ((type Self)) where () ())))
 
     (; impl rust:Drop for i32 { }
-     TraitImplDecl (term (impl () (rust:Drop ((user-ty i32))) where () ())))
+     TraitImplDecl (term (impl () rust:Drop () for i32 where () ())))
 
     (; the crate has the struct, the trait, and the impl
      CrateDecl (term (TheCrate (crate (TraitDecl_Drop
@@ -51,7 +51,7 @@
      TraitDecl_Drop (term (trait rust:Drop ((type Self)) where () ())))
 
     (; impl rust:Drop for Foo<i32> { } //~ ERROR
-     TraitImplDecl (term (impl () (rust:Drop ((rigid-ty Foo ((user-ty i32))))) where () ())))
+     TraitImplDecl (term (impl () rust:Drop () for (Foo i32) where () ())))
 
     (; the crate has the struct, the trait, and the impl
      CrateDecl (term (TheCrate (crate (AdtDecl_Foo
@@ -88,7 +88,7 @@
      TraitDecl_Drop (term (trait rust:Drop ((type Self)) where () ())))
 
     (; impl<U> rust:Drop for Foo<U> where U: Debug { } //~ ERROR
-     TraitImplDecl (term (impl ((type U)) (rust:Drop ((rigid-ty Foo (U)))) where ((U : Debug())) ())))
+     TraitImplDecl (term (impl ((type U)) rust:Drop () for (Foo U) where ((U : Debug())) ())))
 
     (; the crate has the struct, the trait, and the impl
      CrateDecl (term (TheCrate (crate (AdtDecl_Foo
@@ -117,7 +117,7 @@
      TraitDecl_Drop (term (trait rust:Drop ((type Self)) where () {})))
 
     (; impl<U> rust:Drop for Foo<U> { }
-     TraitImplDecl (term (impl ((type U)) (rust:Drop ((rigid-ty Foo (U)))) where () {})))
+     TraitImplDecl (term (impl ((type U)) rust:Drop () for (Foo U) where () {})))
 
     (; the crate has the struct, the trait, and the impl
      CrateDecl (term (TheCrate (crate (AdtDecl_Foo
@@ -159,7 +159,7 @@
 
     (; impl<U> rust:Drop for Foo<U> where T: Ord + Eq { }
      TraitImplDecl (term (impl ((type U))
-                               (rust:Drop ((rigid-ty Foo (U))))
+                               rust:Drop () for (Foo U)
                                where ((U : Ord())
                                       (U : Eq())
                                       )

--- a/src/decl/test/fn-in-impl-vs-trait-absolutely-same.rkt
+++ b/src/decl/test/fn-in-impl-vs-trait-absolutely-same.rkt
@@ -19,7 +19,7 @@
      )
     (; impl Get for () { fn get<T>(&mut self) where T: Debug; }
      TraitImplDecl_Get
-     (term (impl[] (Get[(user-ty ())]) where []
+     (term (impl[] Get[] for () where []
                 {
                  (fn get[(type T) (lifetime l)]((user-ty (&mut l ()))) -> (user-ty ()) where [(T : Debug[])] {})
                  }))

--- a/src/decl/test/fn-in-impl-vs-trait-different-arg-type.rkt
+++ b/src/decl/test/fn-in-impl-vs-trait-different-arg-type.rkt
@@ -21,7 +21,7 @@
     (; impl Get for () { fn get<T>(&self) where T: Debug; }
      ;                             ----- ERROR
      TraitImplDecl_Get
-     (term (impl[] (Get[(user-ty ())]) where []
+     (term (impl[] Get[] for () where []
                 {
                  (fn get[(type T) (lifetime l)]((user-ty (& l ()))) -> (user-ty ()) where [(T : Debug[])] {})
                  }))

--- a/src/decl/test/fn-in-impl-vs-trait-too-few-where-clause.rkt
+++ b/src/decl/test/fn-in-impl-vs-trait-too-few-where-clause.rkt
@@ -22,7 +22,7 @@
     (; impl Get for () { fn get<T>(&mut self) /* where T: Debug */ ;
      ;                                           -------------- OK}
      TraitImplDecl_Get
-     (term (impl[] (Get[(user-ty ())]) where []
+     (term (impl[] Get[] for () where []
                 {(fn get[(type T) (lifetime l)]((user-ty (&mut l ()))) -> (user-ty ()) where [] {})
                  }))
      )

--- a/src/decl/test/fn-in-impl-vs-trait-too-many-where-clause.rkt
+++ b/src/decl/test/fn-in-impl-vs-trait-too-many-where-clause.rkt
@@ -22,7 +22,7 @@
     (; impl Get for () { fn get<T>(&mut self) where T: Debug, T: Copy;
      ;                                                         ------- ERROR}
      TraitImplDecl_Get
-     (term (impl[] (Get[(user-ty ())]) where []
+     (term (impl[] Get[] for () where []
                 {(fn get[(type T) (lifetime l)]((user-ty (&mut l ()))) -> (user-ty ())
                      where [(T : Debug[])
                             (T : rust:Copy[])

--- a/src/decl/test/libcore.rkt
+++ b/src/decl/test/libcore.rkt
@@ -18,8 +18,8 @@
      (TraitDecl_Copy (term (trait rust:Copy ((type Self)) where () {})))
      (TraitDecl_Drop (term (trait rust:Drop ((type Self)) where () {})))
 
-     (TraitImplDecl_Copy_for_u32 (term (impl[] (rust:Copy[(user-ty u32)]) where [] {})))
-     (TraitImplDecl_Copy_for_i32 (term (impl[] (rust:Copy[(user-ty i32)]) where [] {})))
+     (TraitImplDecl_Copy_for_u32 (term (impl[] rust:Copy[] for u32 where [] {})))
+     (TraitImplDecl_Copy_for_i32 (term (impl[] rust:Copy[] for i32 where [] {})))
 
      (CrateDecl_core (term (core (crate [
                                          TraitDecl_Sized

--- a/src/decl/test/multi-crate.rkt
+++ b/src/decl/test/multi-crate.rkt
@@ -19,7 +19,7 @@
      CrateDecl_A (redex-let*
                   formality-decl
                   ((TraitDecl (term (trait Debug ((type Self)) where () {})))
-                   (TraitImplDecl (term (impl () (Debug ((user-ty i32))) where () {})))
+                   (TraitImplDecl (term (impl () Debug () for i32 where () {})))
                    )
                   (term (CrateA (crate (TraitDecl TraitImplDecl))))))
 
@@ -37,7 +37,7 @@
                                  formality-decl
                                  ((TraitDecl_WithDebug (term (trait WithDebug ((type Self) (type T)) where ((T : Debug())) {})))
                                   (AdtDecl_Foo (term (struct Foo ((type T)) where ((T : Debug())) ((Foo ())))))
-                                  (TraitImplDecl (term (impl ((type T)) (WithDebug ((rigid-ty Foo (T)) T)) where () ())))
+                                  (TraitImplDecl (term (impl ((type T)) WithDebug (T) for (Foo T) where () ())))
                                   ((CrateItemDecl_B ...) (term (TraitDecl_WithDebug AdtDecl_Foo TraitImplDecl)))
                                   )
                                  (term ((CrateB (crate (CrateItemDecl_B ...)))

--- a/src/decl/where-clauses.rkt
+++ b/src/decl/where-clauses.rkt
@@ -1,6 +1,7 @@
 #lang racket
 (require redex/reduction-semantics
          "grammar.rkt"
+         "../ty/user-ty.rkt"
          )
 (provide where-clause->goal
          where-clauses->goals
@@ -57,16 +58,20 @@
    (∀ KindedVarIds (where-clause->goal∧clause WhereClause))
    ]
 
-  [(where-clause->goal∧clause (Ty_self : TraitId (Parameter ...)))
-   (is-implemented (TraitId (Ty_self Parameter ...)))
+  [(where-clause->goal∧clause (UserTy_self : TraitId (UserParameter ...)))
+   (is-implemented (TraitId ((user-ty UserTy_self) (user-parameter UserParameter) ...)))
    ]
 
-  [(where-clause->goal∧clause (AliasTy == Ty))
-   (normalizes-to AliasTy Ty)
+  [(where-clause->goal∧clause (UserAliasTy == UserTy))
+   (normalizes-to (user-ty UserAliasTy) (user-ty UserTy))
    ]
 
-  [(where-clause->goal∧clause (Parameter_a : Parameter_b))
-   (Parameter_a -outlives- Parameter_b)
+  [(where-clause->goal∧clause (UserTy : Lt))
+   ((user-ty UserTy) -outlives- Lt)
+   ]
+
+  [(where-clause->goal∧clause (Lt_a >= Lt_b))
+   (Lt_a -outlives- Lt_b)
    ]
 
   )

--- a/src/mir/coherence-orphan.rkt
+++ b/src/mir/coherence-orphan.rkt
@@ -8,6 +8,7 @@
          "../decl/decl-ok.rkt"
          "../decl/decl-to-clause.rkt"
          "../decl/grammar.rkt"
+         "../ty/user-ty.rkt"
          "../logic/instantiate.rkt"
          "prove-goal.rkt"
          )
@@ -23,13 +24,13 @@
   #:contract (✅-OrphanRules DeclProgram TraitImplDecl)
 
   [(where/error (CrateDecls CrateId) DeclProgram)
-   (where/error (impl _ (TraitId _) where _ _) TraitImplDecl)
+   (where/error (impl _ TraitId _ for _ where _ _) TraitImplDecl)
    (where CrateId (crate-defining-trait-with-id CrateDecls TraitId))
    ------------------------------- "orphan--trait-is-in-current-crate"
    (✅-OrphanRules DeclProgram TraitImplDecl)]
 
-  [(where/error (impl KindedVarIds (_ (Parameter_self Parameter_other ...)) where WhereClauses _) TraitImplDecl)
-   (is-local-parameter DeclProgram Parameter_self)
+  [(where/error (impl KindedVarIds _ _ for UserTy_self where WhereClauses _) TraitImplDecl)
+   (is-local-parameter DeclProgram (user-ty UserTy_self))
    ------------------------------- "orphan--self-is-local"
    (✅-OrphanRules DeclProgram TraitImplDecl)]
 

--- a/src/mir/test/coherence-orphan.rkt
+++ b/src/mir/test/coherence-orphan.rkt
@@ -16,7 +16,7 @@
     (AdtDecl_StructA (term (struct StructA[] where [] [(StructA {})])))
 
     ; the various impls one might write
-    (TraitImplDecl_AforA (term (impl[] (TraitA[(user-ty (StructA))]) where [] {})))
+    (TraitImplDecl_AforA (term (impl[] TraitA[] for (StructA) where [] {})))
     ]
 
    (; both trait/struct in same crate

--- a/src/ty/grammar.rkt
+++ b/src/ty/grammar.rkt
@@ -85,9 +85,11 @@
           ScalarId
           (AdtId UserParameter ...)
           (fn UserTys -> UserTy)
-          (< UserTy as TraitId UserParameters > :: AssociatedTyId UserParameters)
+          UserAliasTy
+          (internal Ty) ; this can be removed once only UserTys occur in decls
           VarId
           )
+  (UserAliasTy ::= (< UserTy as TraitId UserParameters > :: AssociatedTyId UserParameters))
   (UserParameters ::= (UserParameter ...))
   (UserParameter ::= UserTy Lt)
 

--- a/src/ty/test/hook.rkt
+++ b/src/ty/test/hook.rkt
@@ -9,6 +9,7 @@
          "../relate.rkt"
          "../scheme.rkt"
          "../predicate.rkt"
+         "../user-ty.rkt"
          "../where-clauses-from-env.rkt"
          )
 (provide env-with-clauses-invariants-and-generics
@@ -105,16 +106,20 @@
    (∀ KindedVarIds (where-clause->goal∧clause WhereClause))
    ]
 
-  [(where-clause->goal∧clause-mock (Ty_self : TraitId (Parameter ...)))
-   (is-implemented (TraitId (Ty_self Parameter ...)))
+  [(where-clause->goal∧clause-mock (UserTy_self : TraitId (UserParameter ...)))
+   (is-implemented (TraitId ((user-ty UserTy_self) (user-parameter UserParameter) ...)))
    ]
 
-  [(where-clause->goal∧clause-mock (AliasTy == Ty))
-   (normalizes-to AliasTy Ty)
+  [(where-clause->goal∧clause-mock (UserAliasTy == UserTy))
+   (normalizes-to (user-ty UserAliasTy) (user-ty UserTy))
    ]
 
-  [(where-clause->goal∧clause-mock (Parameter_a : Parameter_b))
-   (Parameter_a -outlives- Parameter_b)
+  [(where-clause->goal∧clause-mock (UserTy : Lt))
+   ((user-ty UserTy) -outlives- Lt)
+   ]
+
+  [(where-clause->goal∧clause-mock (Lt_a >= Lt_b))
+   (Lt_a -outlives- Lt_b)
    ]
 
   )

--- a/src/ty/user-ty.rkt
+++ b/src/ty/user-ty.rkt
@@ -50,6 +50,8 @@
   [(user-ty (for KindedVarIds UserTy))
    (∀ KindedVarIds (user-ty UserTy))
    ]
+
+  [(user-ty (internal Ty)) Ty]
   )
 
 (define-metafunction formality-ty


### PR DESCRIPTION
This changes the grammar for impls to `(impl KindedVarIds TraitId UserParameters for UserTy where WhereClauses ImplItems)`, making formality code more similar to Rust and thus improves readability.
It also changes the syntax of where clauses to use UserTy and resolves the ambiguity between `T: 'a` and `a': 'b` clauses by using the syntax `Lt_a >= Lt_b` for lifetime outlives clauses.
This has draft status as there are currently still some failing tests.