### PR TITLE
Expand MIR well-formedness rules and implement function input/output goals

### DIFF
--- a/src/mir/all-check.rkt
+++ b/src/mir/all-check.rkt
@@ -120,7 +120,7 @@
 
    ;; construct the typing environment
    (where/error (CrateDecls _) DeclProgram)
-   (where/error Γ (CrateDecls VarIds_∀ (Tys -> Ty where WhereClauses) LocalsAndBlocks_2))
+   (where/error Γ (CrateDecls VarIds_∀ (Tys -> Ty where WhereClauses) VarIds_∃ LocalsAndBlocks_2))
 
    ;; run the checks
    (well-formed/Γ Γ)

--- a/src/mir/grammar-extended.rkt
+++ b/src/mir/grammar-extended.rkt
@@ -84,7 +84,7 @@
 
 (define-metafunction formality-mir-extended
   ;; Returns the `CrateDecls` from the environment Γ
-  crate-decls-of-Γ : Γ -> MirBody
+  crate-decls-of-Γ : Γ -> CrateDecls
 
   [(crate-decls-of-Γ (CrateDecls _ _ _)) CrateDecls]
   )

--- a/src/mir/grammar-extended.rkt
+++ b/src/mir/grammar-extended.rkt
@@ -6,7 +6,7 @@
 
 (define-extended-language formality-mir-extended formality-mir
   ;; Typing context storing bindings from locals to types and `CrateDecls`.
-  (Γ ::= (CrateDecls VarIds_∀ (Tys -> Ty where WhereClauses) LocalsAndBlocks))
+  (Γ ::= (CrateDecls VarIds_∀ (Tys -> Ty where WhereClauses) VarIds_∃ LocalsAndBlocks))
 
   ;; MaybeVariantId -- either a variant-id or nothing
   (MaybeVariantId ::= () (VariantId))
@@ -61,7 +61,7 @@
   ;; Returns the `MirBody` from the environment Γ
   locals-and-blocks-of-Γ : Γ -> LocalsAndBlocks
 
-  [(locals-and-blocks-of-Γ (_ _ _ LocalsAndBlocks)) LocalsAndBlocks]
+  [(locals-and-blocks-of-Γ (_ _ _ _ LocalsAndBlocks)) LocalsAndBlocks]
   )
 
 (define-metafunction formality-mir-extended
@@ -86,5 +86,5 @@
   ;; Returns the `CrateDecls` from the environment Γ
   crate-decls-of-Γ : Γ -> CrateDecls
 
-  [(crate-decls-of-Γ (CrateDecls _ _ _)) CrateDecls]
+  [(crate-decls-of-Γ (CrateDecls _ _ _ _)) CrateDecls]
   )

--- a/src/mir/type-check-goal.rkt
+++ b/src/mir/type-check-goal.rkt
@@ -39,14 +39,15 @@
   #:mode (type-check-goal/inputs-and-outputs I O)
   #:contract (type-check-goal/inputs-and-outputs Γ GoalAtLocations)
 
-  [; FIXME: check that the "return local" has the same type as the one given in Γ
-   ;
-   ; FIXME: check that the types from the signature in Γ correspond to the types of the
-   ; corresponding local variables
-   ;
+  [(where/error (_ _ ((Ty_sigarg ..._n) -> Ty_sigret _ _) _) Γ)
+   (where/error ((_ Ty_locret _) (_ Ty_locarg _) ..._n _ ...) (local-decls-of-Γ Γ))
+   (where/error ((BasicBlockId_first _) _ ...) (basic-block-decls-of-Γ Γ))
+   (where/error Location (BasicBlockId_first @ 0))
    ; FIXME: check that the where-clauses in signature are well-formed?
    ----------------------------------------
-   (type-check-goal/inputs-and-outputs Γ ())
+   (type-check-goal/inputs-and-outputs Γ ((Location (Ty_sigret == Ty_locret))
+                                          (Location (Ty_sigarg == Ty_locarg)) ...
+                                          ))
    ]
   )
 

--- a/src/mir/type-check-goal.rkt
+++ b/src/mir/type-check-goal.rkt
@@ -39,9 +39,10 @@
   #:mode (type-check-goal/inputs-and-outputs I O)
   #:contract (type-check-goal/inputs-and-outputs Γ GoalAtLocations)
 
-  [(where/error (_ _ ((Ty_sigarg ..._n) -> Ty_sigret _ _) _) Γ)
+  [(where/error (_ _ ((Ty_sigarg ..._n) -> Ty_sigret _ _) _ _) Γ)
    (where/error ((_ Ty_locret _) (_ Ty_locarg _) ..._n _ ...) (local-decls-of-Γ Γ))
    (where/error ((BasicBlockId_first _) _ ...) (basic-block-decls-of-Γ Γ))
+   ; TODO: the goals should hold at "all locations"
    (where/error Location (BasicBlockId_first @ 0))
    ; FIXME: check that the where-clauses in signature are well-formed?
    ----------------------------------------

--- a/src/mir/type-of.rkt
+++ b/src/mir/type-of.rkt
@@ -2,6 +2,7 @@
 (require redex/reduction-semantics
          "grammar-extended.rkt"
          "../logic/substitution.rkt"
+         "../ty/user-ty.rkt"
          )
 (provide type-of/Place
          type-of/Rvalue
@@ -157,13 +158,13 @@
   [; ref
    (type-of/Place Γ Place Ty)
    ------------------------------------------
-   (type-of/Rvalue Γ (ref Lt () Place) (& Lt Ty))
+   (type-of/Rvalue Γ (ref Lt () Place) (rigid-ty (ref ()) (Lt Ty)))
    ]
 
   [; ref-mut
    (type-of/Place Γ Place Ty)
    ------------------------------------------
-   (type-of/Rvalue Γ (ref Lt mut Place) (&mut Lt Ty))
+   (type-of/Rvalue Γ (ref Lt mut Place) (rigid-ty (ref mut) (Lt Ty)))
    ]
 
   [; binop

--- a/src/mir/well-formed-mir.rkt
+++ b/src/mir/well-formed-mir.rkt
@@ -125,8 +125,9 @@
    ]
 
   [(well-formed/Place Γ Place)
+   (well-formed/Lt Γ Lt)
    ----------------------------------------
-   (well-formed/Rvalue Γ (ref _ _ Place))
+   (well-formed/Rvalue Γ (ref Lt _ Place))
    ]
 
   [(well-formed/Place Γ Place)
@@ -255,6 +256,23 @@
    (well-formed/BasicBlockId Γ BasicBlockId_unwind)
    ----------------------------------------
    (well-formed/TargetIds Γ (BasicBlockId_normal BasicBlockId_unwind))
+   ]
+
+  )
+
+(define-judgment-form
+  formality-mir-extended
+  #:mode (well-formed/Lt I I)
+  #:contract (well-formed/Lt Γ Lt)
+
+  [----------------------------------------
+   (well-formed/Lt Γ static)
+   ]
+
+  [(where/error (_ (VarId_∀ ...) _ (VarId_∃ ...) _) Γ)
+   (where (_ ... VarId _ ...) (VarId_∀ ... VarId_∃ ...))
+   ----------------------------------------
+   (well-formed/Lt Γ VarId)
    ]
 
   )

--- a/src/mir/well-formed-mir.rkt
+++ b/src/mir/well-formed-mir.rkt
@@ -53,9 +53,24 @@
    (well-formed/Statement Γ noop)
    ]
 
+  [(well-formed/LocalId Γ LocalId)
+   ----------------------------------------
+   (well-formed/Statement Γ (storage-live LocalId))
+   ]
+
+  [(well-formed/LocalId Γ LocalId)
+   ----------------------------------------
+   (well-formed/Statement Γ (storage-dead LocalId))
+   ]
+
   [(well-formed/Place Γ Place)
-  (well-formed/Rvalue Γ Rvalue)
-    ----------------------------------------
+   ----------------------------------------
+   (well-formed/Statement Γ (set-discriminant Place _))
+   ]
+
+  [(well-formed/Place Γ Place)
+   (well-formed/Rvalue Γ Rvalue)
+   ----------------------------------------
    (well-formed/Statement Γ (Place = Rvalue))
    ]
 
@@ -71,6 +86,27 @@
    (well-formed/Place Γ LocalId)
    ]
 
+  [(well-formed/Place Γ Place)
+   ----------------------------------------
+   (well-formed/Place Γ (* Place))
+   ]
+
+  [(well-formed/Place Γ Place)
+   ----------------------------------------
+   (well-formed/Place Γ (field Place _))
+   ]
+
+  [(well-formed/Place Γ Place)
+   (well-formed/LocalId Γ LocalId)
+   ----------------------------------------
+   (well-formed/Place Γ (index Place LocalId))
+   ]
+
+  [(well-formed/Place Γ Place)
+   ----------------------------------------
+   (well-formed/Place Γ (downcast Place _))
+   ]
+
   )
 
 (define-judgment-form
@@ -83,9 +119,35 @@
    (well-formed/Rvalue Γ (use Operand))
    ]
 
+  [(well-formed/Operand Γ Operand)
+   ----------------------------------------
+   (well-formed/Rvalue Γ (repeat Operand _))
+   ]
+
+  [(well-formed/Place Γ Place)
+   ----------------------------------------
+   (well-formed/Rvalue Γ (ref _ _ Place))
+   ]
+
+  [(well-formed/Place Γ Place)
+   ----------------------------------------
+   (well-formed/Rvalue Γ (addr-of _ Place))
+   ]
+
+  [(well-formed/Place Γ Place)
+   ----------------------------------------
+   (well-formed/Rvalue Γ (len Place))
+   ]
+
+  [(well-formed/Operand Γ Operand_rhs)
+   (well-formed/Operand Γ Operand_lhs)
+   ----------------------------------------
+   (well-formed/Rvalue Γ (BinaryOp Operand_rhs Operand_lhs))
+   ]
+
   )
 
-  (define-judgment-form
+(define-judgment-form
   formality-mir-extended
   #:mode (well-formed/Operand I I)
   #:contract (well-formed/Operand Γ Operand)
@@ -95,12 +157,12 @@
    (well-formed/Operand Γ (copy Place))
    ]
 
-   [(well-formed/Place Γ Place)
+  [(well-formed/Place Γ Place)
    ----------------------------------------
    (well-formed/Operand Γ (move Place))
    ]
 
-   [----------------------------------------
+  [----------------------------------------
    (well-formed/Operand Γ (const number))
    ]
 
@@ -128,12 +190,41 @@
    (well-formed/Terminator Γ (goto BasicBlockId))
    ]
 
-   [----------------------------------------
+  [----------------------------------------
+   (well-formed/Terminator Γ resume)
+   ]
+
+  [----------------------------------------
+   (well-formed/Terminator Γ abort)
+   ]
+
+  [----------------------------------------
    (well-formed/Terminator Γ return)
    ]
 
-   [----------------------------------------
-   (well-formed/Terminator Γ resume)
+  [----------------------------------------
+   (well-formed/Terminator Γ unreachable)
+   ]
+
+  [(well-formed/Place Γ Place)
+   (well-formed/TargetIds Γ TargetIds)
+   ----------------------------------------
+   (well-formed/Terminator Γ (drop Place TargetIds))
+   ]
+
+  [(well-formed/Place Γ Place)
+   (well-formed/Operand Γ Operand)
+   (well-formed/TargetIds Γ TargetIds)
+   ----------------------------------------
+   (well-formed/Terminator Γ (drop-and-replace Place Operand TargetIds))
+   ]
+
+  [(well-formed/Operand Γ Operand_fn)
+   (well-formed/Operand Γ Operand_arg) ...
+   (well-formed/Place Γ Place)
+   (well-formed/TargetIds Γ TargetIds)
+   ----------------------------------------
+   (well-formed/Terminator Γ (call Operand_fn (Operand_arg ...) Place TargetIds))
    ]
 
   )
@@ -150,3 +241,20 @@
 
   )
 
+(define-judgment-form
+  formality-mir-extended
+  #:mode (well-formed/TargetIds I I)
+  #:contract (well-formed/TargetIds Γ TargetIds)
+
+  [(well-formed/BasicBlockId Γ BasicBlockId)
+   ----------------------------------------
+   (well-formed/TargetIds Γ (BasicBlockId))
+   ]
+
+  [(well-formed/BasicBlockId Γ BasicBlockId_normal)
+   (well-formed/BasicBlockId Γ BasicBlockId_unwind)
+   ----------------------------------------
+   (well-formed/TargetIds Γ (BasicBlockId_normal BasicBlockId_unwind))
+   ]
+
+  )

--- a/src/rust/test/type-check--return-ref-to-local.rkt
+++ b/src/rust/test/type-check--return-ref-to-local.rkt
@@ -9,27 +9,21 @@
 (module+ test
   ;; Program:
   ;;
-  ;; fn foo<'a>() -> &'a u32 {
+  ;; fn foo<'a>() -> &'a i32 {
   ;;     let x = 22;
   ;;     &x
   ;; }
-  (traced '(borrow-check
-            type-check-goal/Γ
-            ✅-FnBody
-            well-formed/Γ
-            unsafe-check
-            well-formed/BasicBlockDecl
-            well-formed/Statement)
+  (traced '(borrow-check)
           (test-equal
            #t
            (term (rust:is-core-crate-ok
-                  [(fn foo[(lifetime a)] () -> (& a u32)
+                  [(fn foo[(lifetime a)] () -> (& a i32)
                        where []
                        { ∃ [(lifetime ?a)
                             (lifetime ?b)
                             ]
-                           ([(_0 (user-ty (& ?a u32)) mut)
-                             (_1 (user-ty u32) ()) ; the variable `x`
+                           ([(_0 (user-ty (& ?a i32)) mut)
+                             (_1 (user-ty i32) ()) ; the variable `x`
                              ]
 
                             [(bb0 { [(_1 = (use (const 22))) ; x = 22


### PR DESCRIPTION
This makes the `type-check--return-ref-to-local` test pass.