### PR TITLE
initialization check, first draft

### DIFF
--- a/src/body/borrow-check.rkt
+++ b/src/body/borrow-check.rkt
@@ -1,6 +1,8 @@
 #lang racket
 (require redex/reduction-semantics
          "grammar.rkt"
+         "borrow-check/initialization-check.rkt"
+         "borrow-check/initialization-infer.rkt"
          )
 (provide borrow-check
          )
@@ -10,9 +12,8 @@
   #:mode (borrow-check I I)
   #:contract (borrow-check Γ GoalAtLocations)
 
-  [; FIXME: Prove that GoalAtLocations are valid, yielding a set of constraints.
-   ;
-   ; FIXME: Feed those constraints into the borrow checker rules.
+  [(initialization-check Γ (infer-initialization Γ))
+   ; FIXME: ...the rest of the check
    ----------------------------------------
    (borrow-check Γ GoalAtLocations)
    ]

--- a/src/body/borrow-check/initialization-check.rkt
+++ b/src/body/borrow-check/initialization-check.rkt
@@ -1,0 +1,309 @@
+#lang racket
+(require redex/reduction-semantics
+         "../grammar.rkt"
+         "initialization-update.rkt"
+         "move-set.rkt"
+         )
+(provide initialization-check
+         )
+
+(define-judgment-form
+  formality-body
+  ;; Check that the function body only uses initialized data, given the set `MoveSetMap` of
+  ;; places moved on entry to each block.
+  #:mode (initialization-check I I)
+  #:contract (initialization-check Γ MoveSetMap)
+
+  [(where/error [BasicBlockDecl ...] (basic-block-decls-of-Γ Γ))
+
+   ; each block and its successors must be consistent with `MoveSetMap`
+   (initialization-check-block MoveSetMap BasicBlockDecl) ...
+
+   ; the entry block must consider all local variables as moved
+   (initialization-check-entry Γ MoveSetMap)
+   ----------------------------------------
+   (initialization-check Γ MoveSetMap)
+   ]
+  )
+
+
+(define-judgment-form
+  formality-body
+  ;; Check that the entry block doesn't assume anything is initialized on entry.
+  #:mode (initialization-check-entry I I)
+  #:contract (initialization-check-entry Γ MoveSetMap)
+
+  [(where/error BasicBlockId_entry (entry-basic-block-id-of-Γ Γ))
+   (initialization-check-successor MoveSetMap BasicBlockId_entry (initial-move-set Γ))
+   ----------------------------------------
+   (initialization-check-entry Γ MoveSetMap)
+   ]
+  )
+
+(define-judgment-form
+  formality-body
+  ;; Check that the block only uses initialized data, given the set `MoveSetMap` of
+  ;; places moved on entry to each block. Also checks that the moved-on-entry sets
+  ;; for the successors of this block account for moves performed during this block.
+  #:mode (initialization-check-block I I)
+  #:contract (initialization-check-block MoveSetMap BasicBlockDecl)
+
+  [(where/error [_ ... (BasicBlockId MoveSet) _ ...] MoveSetMap)
+   (initialization-check-block-data MoveSet BasicBlockData [(BasicBlockId_succ MoveSet_succ) ...])
+   (initialization-check-successor MoveSetMap BasicBlockId_succ MoveSet_succ) ...
+   ----------------------------------------
+   (initialization-check-block MoveSetMap (BasicBlockId BasicBlockData))
+   ]
+  )
+
+(define-judgment-form
+  formality-body
+  ;; Check that the move-set on entry to `BasicBlockId` lists
+  ;; each place in `Places` as moved.
+  #:mode (initialization-check-successor I I I)
+  #:contract (initialization-check-successor MoveSetMap BasicBlockId Places)
+
+  [(where/error [_ ... (BasicBlockId MoveSet_block) _ ...] MoveSetMap)
+   (place-fully-moved MoveSet_block Place_moved) ...
+   ----------------------------------------
+   (initialization-check-successor MoveSetMap BasicBlockId [Place_moved ...])
+   ]
+  )
+(define-judgment-form
+  formality-body
+  ;; Check that each piece of data accessed in the block body is fully initialized.
+  ;; Output a `MoveSetMap` containing places that must be marked as moved in the successors.
+  ;;
+  ;; `MoveSet` contains the places that are moved on entry to the block.
+  #:mode (initialization-check-block-data I I O)
+  #:contract (initialization-check-block-data MoveSet BasicBlockData MoveSetMap_succ)
+
+  [(where/error ([(MoveSet_statement Statement) ...] MoveSet_terminator)
+                (move-sets-for-statements MoveSet_on-entry Statements))
+   (initialization-check-statement MoveSet_statement Statement) ...
+   (initialization-check-terminator MoveSet_terminator Terminator)
+   (where/error MoveSetMap_succ (move-sets-for-terminator MoveSet_terminator Terminator))
+   ----------------------------------------
+   (initialization-check-block-data MoveSet_on-entry (Statements Terminator) MoveSetMap_succ)
+   ]
+  )
+
+(define-judgment-form
+  formality-body
+  ;; Check that each piece of data accessed in `Terminator` is initialized.
+  ;;
+  ;; `MoveSet` contains the places that are moved on entry to the terminator.
+  #:mode (initialization-check-terminator I I)
+  #:contract (initialization-check-terminator MoveSet Terminator)
+
+  [----------------------------------------
+   (initialization-check-terminator MoveSet (goto BasicBlockId))
+   ]
+
+  [----------------------------------------
+   (initialization-check-terminator MoveSet resume)
+   ]
+
+  [----------------------------------------
+   (initialization-check-terminator MoveSet abort)
+   ]
+
+  [----------------------------------------
+   (initialization-check-terminator MoveSet return)
+   ]
+
+  [----------------------------------------
+   (initialization-check-terminator MoveSet unreachable)
+   ]
+
+  [----------------------------------------
+   (initialization-check-terminator MoveSet (drop Place TargetIds))
+   ]
+
+  [----------------------------------------
+   (initialization-check-terminator MoveSet (drop-and-replace Place TargetIds))
+   ]
+
+  [(initialization-check-operands MoveSet [Operand_f Operand_a ...])
+   ----------------------------------------
+   (initialization-check-terminator MoveSet (call Operand_f [Operand_a ...] Place TargetIds))
+   ]
+
+  )
+
+(define-judgment-form
+  formality-body
+  ;; Check that each piece of data accessed in `Statement` is initialized.
+  ;;
+  ;; `MoveSet` contains the places that are moved on entry to the statement.
+  #:mode (initialization-check-statement I I)
+  #:contract (initialization-check-statement MoveSet Statement)
+
+  [(initialization-check-rvalue MoveSet Rvalue)
+   (where/error MoveSet_rvalue (update-move-set-from-rvalue MoveSet Rvalue))
+   (place-assignable MoveSet_rvalue Place)
+   ----------------------------------------
+   (initialization-check-statement MoveSet (Place = Rvalue))
+   ]
+
+  [(place-fully-initialized MoveSet Place)
+   ----------------------------------------
+   (initialization-check-statement MoveSet (set-discriminant Place VariantId))
+   ]
+
+  [; FIXME: What, if any, conditions should we check for storage-live?
+   ----------------------------------------
+   (initialization-check-statement MoveSet (storage-live LocalId))
+   ]
+
+  [; FIXME: What, if any, conditions should we check for storage-dead?
+   ----------------------------------------
+   (initialization-check-statement MoveSet (storage-dead LocalId))
+   ]
+
+  [; FIXME: What, if any, conditions should we check for storage-dead?
+   ----------------------------------------
+   (initialization-check-statement MoveSet noop)
+   ]
+  )
+
+(define-judgment-form
+  formality-body
+  ;; Check that each piece of data accessed in `Rvalue` is initialized.
+  ;;
+  ;; `MoveSet` contains the places that are moved on entry to the rvalue.
+  #:mode (initialization-check-rvalue I I)
+  #:contract (initialization-check-rvalue MoveSet Rvalue)
+
+  [(initialization-check-operand MoveSet Operand)
+   ----------------------------------------
+   (initialization-check-rvalue MoveSet (use Operand))
+   ]
+
+  [(initialization-check-operand MoveSet Operand)
+   ----------------------------------------
+   (initialization-check-rvalue MoveSet (repeat Operand Constant))
+   ]
+
+  [(place-fully-initialized MoveSet Place)
+   ----------------------------------------
+   (initialization-check-rvalue MoveSet (ref Lt MaybeMut Place))
+   ]
+
+  [(place-fully-initialized MoveSet Place)
+   ----------------------------------------
+   (initialization-check-rvalue MoveSet (addr-of MaybeMut Place))
+   ]
+
+  [(place-fully-initialized MoveSet Place)
+   ----------------------------------------
+   (initialization-check-rvalue MoveSet (len Place))
+   ]
+
+  [(initialization-check-operands MoveSet [Operand_l Operand_r])
+   ----------------------------------------
+   (initialization-check-rvalue MoveSet (BinaryOp Operand_l Operand_r))
+   ]
+  )
+
+(define-judgment-form
+  formality-body
+  ;; Check that each piece of data accessed in `Operands` is initialized;
+  ;; the operands are assumed to be evaluated in order, so it's an error if one
+  ;; of them moves data that is then used by a later operand.
+  ;;
+  ;; `MoveSet` contains the places that are moved on entry to the operands.
+  #:mode (initialization-check-operands I I)
+  #:contract (initialization-check-operands MoveSet Operands)
+
+  [
+   ----------------------------------------
+   (initialization-check-operands MoveSet [])
+   ]
+
+  [(initialization-check-operand MoveSet_0 Operand_0)
+   (where/error MoveSet_1 (update-move-set-from-operand MoveSet_0 Operand_0))
+   (initialization-check-operands MoveSet_1 [Operand_1 ...])
+   ----------------------------------------
+   (initialization-check-operands MoveSet_0 [Operand_0 Operand_1 ...])
+   ]
+  )
+
+(define-judgment-form
+  formality-body
+  ;; Check that each piece of data accessed in `Operand` is initialized.
+  ;;
+  ;; `MoveSet` contains the places that are moved on entry to the operand.
+  #:mode (initialization-check-operand I I)
+  #:contract (initialization-check-operand MoveSet Operand)
+
+  [(place-fully-initialized MoveSet Place)
+   ----------------------------------------
+   (initialization-check-operand MoveSet (CopyMove Place))
+   ]
+
+  [----------------------------------------
+   (initialization-check-operand MoveSet (const Constant))
+   ]
+  )
+
+(define-judgment-form
+  formality-body
+  ;; Check that the given place is fully initialized, given the set of places `MoveSet`
+  ;; that have been moved.
+  #:mode (place-fully-initialized I I)
+  #:contract (place-fully-initialized MoveSet Place)
+
+  [(where #t (place-is-fully-initialized? MoveSet Place))
+   ----------------------------------------
+   (place-fully-initialized MoveSet Place)
+   ]
+  )
+
+(define-judgment-form
+  formality-body
+  ;; Check that the given place is fully moved, given the set of places `MoveSet`
+  ;; that have been moved.
+  #:mode (place-fully-moved I I)
+  #:contract (place-fully-moved MoveSet Place)
+
+  [(where #t (place-is-fully-moved? MoveSet Place))
+   ----------------------------------------
+   (place-fully-moved MoveSet Place)
+   ]
+  )
+
+(define-judgment-form
+  formality-body
+  ;; Check that the given place can be assigned, given the set of places `MoveSet`
+  ;; that have been moved.
+  ;;
+  ;; Rust does not permit `x.f = y` if `x` is not initialized.
+  #:mode (place-assignable I I)
+  #:contract (place-assignable MoveSet Place)
+
+  [
+   ----------------------------------------
+   (place-assignable _ LocalId)
+   ]
+
+  [(; is this right? seems too strict
+    place-fully-initialized MoveSet Place)
+   ----------------------------------------
+   (place-assignable MoveSet (* Place))
+   ]
+
+  [(; is this right? seems too strict
+    place-fully-initialized MoveSet Place)
+   ----------------------------------------
+   (place-assignable MoveSet (field Place FieldId))
+   ]
+
+
+  [(; is this right? seems too strict
+    place-fully-initialized MoveSet Place)
+   (place-fully-initialized MoveSet LocalId)
+   ----------------------------------------
+   (place-assignable MoveSet (index Place LocalId))
+   ]
+  )

--- a/src/body/borrow-check/initialization-infer.rkt
+++ b/src/body/borrow-check/initialization-infer.rkt
@@ -1,0 +1,86 @@
+#lang racket
+(require redex/reduction-semantics
+         "../grammar.rkt"
+         "move-set.rkt"
+         "move-set-map.rkt"
+         "initialization-update.rkt"
+         )
+(provide infer-initialization
+         )
+
+(define-metafunction formality-body
+  ;; Given a fn body, computes the initialization state on entry to each basic block using a
+  ;; fixed-point, iterative process.
+  ;;
+  ;; Note that inference is intentionally separating from checking, which is found in `initialization-check`.
+  ;; The idea is that inference is not "trusted" -- it infers a `MoveSetMap` that reflects what the program does,
+  ;; but the program may still fail the check (and, if inference is broken, and e.g. identifies things as
+  ;; initialized which are not, then the check should fail).
+  infer-initialization : Γ -> MoveSetMap
+
+  [(infer-initialization Γ)
+   (infer-initialization-fix BasicBlockDecls MoveSetMap)
+
+   ; create an initial map where all local variables are moved on entry,
+   ; and everything else is empty.
+   (where/error BasicBlockDecls (basic-block-decls-of-Γ Γ))
+   (where/error [(BasicBlockId_0 BasicBlockData_0) (BasicBlockId_1 BasicBlockData_1) ...] BasicBlockDecls)
+   (where/error MoveSet_all (initial-move-set Γ))
+   (where/error MoveSetMap [(BasicBlockId_0 MoveSet_all)
+                            (BasicBlockId_1 []) ...
+                            ])
+   ]
+  )
+
+(define-metafunction formality-body
+  ;; Infers the initialization state on entry to each block, iterating
+  ;; until a fixed point is reached.
+  infer-initialization-fix : BasicBlockDecls MoveSetMap -> MoveSetMap
+
+  [; Fixed point reached?
+   (infer-initialization-fix BasicBlockDecls MoveSetMap)
+   MoveSetMap
+   (where MoveSetMap (infer-initialization-for-each-block BasicBlockDecls MoveSetMap))
+   ]
+
+  [; Iterate
+   (infer-initialization-fix BasicBlockDecls MoveSetMap)
+   (infer-initialization-fix BasicBlockDecls MoveSetMap_1)
+   (where MoveSetMap_1 (infer-initialization-for-each-block BasicBlockDecls MoveSetMap))
+   ]
+  )
+
+(define-metafunction formality-body
+  ;; Updates the initialization state for the successors of basic blocks based on that
+  ;; block's current input state and returns a new `MoveSetMap`.
+  infer-initialization-for-each-block : BasicBlockDecls MoveSetMap -> MoveSetMap
+
+  [(infer-initialization-for-each-block [] MoveSetMap)
+   MoveSetMap
+   ]
+
+  [(infer-initialization-for-each-block [BasicBlockDecl_0 BasicBlockDecl_1 ...] MoveSetMap)
+   (infer-initialization-for-each-block [BasicBlockDecl_1 ...] MoveSetMap_0)
+   (where/error MoveSetMap_0 (infer-initialization-for-block BasicBlockDecl_0 MoveSetMap))
+   ]
+  )
+
+(define-metafunction formality-body
+  ;; Updates the initialization state for a single basic block.
+  ;; Returns a new `MoveSetMap` where the state for the successors
+  ;; of this block has been updated appropriately.
+  infer-initialization-for-block : BasicBlockDecl MoveSetMap -> MoveSetMap
+
+  [(infer-initialization-for-block (BasicBlockId (Statements Terminator)) MoveSetMap_in)
+   (union-move-set-maps MoveSetMap_in MoveSetMap_out)
+
+   ; find the current move-set on entry to the block
+   (where/error [_ ... (BasicBlockId MoveSet_0) _ ...] MoveSetMap_in)
+
+   ; account for the statements
+   (where/error ([(MoveSet_s Statement) ...] MoveSet_t) (move-sets-for-statements MoveSet_0 Statements))
+
+   ; account for the terminator
+   (where/error MoveSetMap_out (move-sets-for-terminator MoveSet_t Terminator))
+   ]
+  )

--- a/src/body/borrow-check/initialization-update.rkt
+++ b/src/body/borrow-check/initialization-update.rkt
@@ -1,0 +1,195 @@
+#lang racket
+(require redex/reduction-semantics
+         "../grammar.rkt"
+         "move-set.rkt"
+         "move-set-map.rkt"
+         )
+(provide move-sets-for-terminator
+         move-sets-for-statements
+         update-move-set-from-statement
+         update-move-set-from-rvalue
+         update-move-set-from-operand
+         update-move-set-from-operands
+         )
+
+(define-metafunction formality-body
+  ;; Computes the move-sets that result from a terminator, returning a list
+  ;; of `(BasicBlockId MoveSet)` pairs. Each pair indicates that the
+  ;; block `BasicBlockId` must consider the paths in `MoveSet` moved (in addition to, potentially,
+  ;; others).
+  ;;
+  ;; Subtle point: some terminators, notably `Call`, have different effects on different
+  ;; blocks, as the destination place is only initialized on the "ok" path and not
+  ;; on the panic path.
+  move-sets-for-terminator : MoveSet Terminator -> MoveSetMap
+
+  [(move-sets-for-terminator MoveSet (goto BasicBlockId))
+   [(BasicBlockId MoveSet)]
+   ]
+
+  [(move-sets-for-terminator MoveSet resume)
+   []
+   ]
+
+  [(move-sets-for-terminator MoveSet abort)
+   []
+   ]
+
+  [(move-sets-for-terminator MoveSet return)
+   []
+   ]
+
+  [(move-sets-for-terminator MoveSet unreachable)
+   []
+   ]
+
+  [(move-sets-for-terminator MoveSet (drop Place [BasicBlockId ...]))
+   [(BasicBlockId MoveSet) ...]
+
+   ; We consider `Place` to be dropped after this terminator.
+   (where/error MoveSet_drop (add-moved-place MoveSet Place))
+   ]
+
+  #;[;; FIXME-- I don't remember what this means
+     (move-sets-for-terminator MoveSet (drop-and-replace Place [BasicBlockId ...]))
+     [(BasicBlockId MoveSet) ...]
+
+     ; We consider `Place` to be dropped after this terminator.
+     (where/error MoveSet_drop (add-moved-place MoveSet Place))
+     ]
+
+  [(move-sets-for-terminator MoveSet (call Operand_fn [Operand_arg ...] Place_dest [BasicBlockId_ok]))
+   [(BasicBlockId_ok MoveSet_ok)]
+
+   ; This fn cannot panic: first we move out from the operands, then assign to `Place_dest`.
+   (where/error MoveSet_panic (update-move-set-from-operands MoveSet [Operand_fn Operand_arg ...]))
+   (where/error MoveSet_ok (add-initialized-place MoveSet_panic Place_dest))
+   ]
+
+  [(move-sets-for-terminator MoveSet (call Operand_fn [Operand_arg ...] Place_dest [BasicBlockId_ok BasicBlockId_panic]))
+   [(BasicBlockId_panic MoveSet_panic)
+    (BasicBlockId_ok MoveSet_ok)]
+
+   ; First we move out from the operands. If the fn panics, this is the final state.
+   (where/error MoveSet_panic (update-move-set-from-operands MoveSet [Operand_fn Operand_arg ...]))
+
+   ; If it successfully returns, then we initialize `Place_dest` too.
+   (where/error MoveSet_ok (add-initialized-place MoveSet_panic Place_dest))
+   ]
+
+  )
+
+(define-metafunction formality-body
+  ;; Update a `MoveSet` to show the effects of executing a single `Statement`.
+  move-sets-for-statements : MoveSet_on-entry Statements -> MoveSetsForStatements
+
+  [(move-sets-for-statements MoveSet_on-entry Statements)
+   (accumulate-move-set-for-statements ([] MoveSet_on-entry) Statements)
+   ]
+  )
+
+(define-metafunction formality-body
+  ;; Update a `MoveSet` to show the effects of executing a single `Statement`.
+  accumulate-move-set-for-statements : MoveSetsForStatements Statements -> MoveSetsForStatements
+
+  [(accumulate-move-set-for-statements MoveSetsForStatements [])
+   MoveSetsForStatements
+   ]
+
+  [(accumulate-move-set-for-statements ([(MoveSet_0 Statement_0) ...] MoveSet_1) [Statement_1 Statement_2 ...])
+   (accumulate-move-set-for-statements ([(MoveSet_0 Statement_0) ... (MoveSet_1 Statement_1)] MoveSet_2)
+                                       [Statement_2 ...])
+   (where/error MoveSet_2 (update-move-set-from-statement MoveSet_1 Statement_1))
+   ]
+  )
+
+(define-metafunction formality-body
+  ;; Update a `MoveSet` to show the effects of executing a single `Statement`.
+  update-move-set-from-statement : MoveSet Statement -> MoveSet
+
+  [(update-move-set-from-statement MoveSet_0 (Place = Rvalue))
+   MoveSet_2
+   (where/error MoveSet_1 (update-move-set-from-rvalue MoveSet_0 Rvalue))
+   (where/error MoveSet_2 (add-initialized-place MoveSet_1 Place))
+   ]
+
+  [(update-move-set-from-statement MoveSet (set-discriminant Place VariantId))
+   MoveSet
+   ]
+
+  [(update-move-set-from-statement MoveSet (storage-live LocalId))
+   MoveSet
+   ]
+
+  [(update-move-set-from-statement MoveSet (storage-dead LocalId))
+   MoveSet
+   ]
+
+  [(update-move-set-from-statement MoveSet noop)
+   MoveSet
+   ]
+
+  )
+
+(define-metafunction formality-body
+  ;; Update a `MoveSet` to show the effects of executing a single `Rvalue`.
+  update-move-set-from-rvalue : MoveSet Rvalue -> MoveSet
+
+  [(update-move-set-from-rvalue MoveSet (use Operand))
+   (update-move-set-from-operand MoveSet Operand)
+   ]
+
+  [(update-move-set-from-rvalue MoveSet (repeat Operand Constant))
+   (update-move-set-from-operand MoveSet Operand)
+   ]
+
+  [(update-move-set-from-rvalue MoveSet (ref Lt MaybeMut Place))
+   MoveSet
+   ]
+
+  [(update-move-set-from-rvalue MoveSet (addr-of MaybeMut Place))
+   MoveSet
+   ]
+
+  [(update-move-set-from-rvalue MoveSet (len Place))
+   MoveSet
+   ]
+
+  [(update-move-set-from-rvalue MoveSet (BinaryOp Operand_l Operand_r))
+   (update-move-set-from-operands MoveSet [Operand_l Operand_r])
+   ]
+
+  )
+
+(define-metafunction formality-body
+  ;; Update a `MoveSet` to show the effects of consuming a single operand
+  update-move-set-from-operand : MoveSet Operand -> MoveSet
+
+  [(update-move-set-from-operand MoveSet (copy Place))
+   MoveSet
+   ]
+
+  [(update-move-set-from-operand MoveSet (move Place))
+   (place-set-add MoveSet Place)
+   ]
+
+  [(update-move-set-from-operand MoveSet (const Constant))
+   MoveSet
+   ]
+
+  )
+
+(define-metafunction formality-body
+  ;; Update a `MoveSet` to show the effects of consuming a list of operands
+  update-move-set-from-operands : MoveSet Operands -> MoveSet
+
+  [(update-move-set-from-operands MoveSet [])
+   Operand
+   ]
+
+  [(update-move-set-from-operands MoveSet [Operand_0 Operand_1 ...])
+   (update-move-set-from-operands (update-move-set-from-operand MoveSet Operand_0)
+                                  [Operand_1 ...])
+   ]
+
+  )

--- a/src/body/borrow-check/move-set-map.rkt
+++ b/src/body/borrow-check/move-set-map.rkt
@@ -1,0 +1,49 @@
+#lang racket
+(require redex/reduction-semantics
+         "../grammar.rkt"
+         "move-set.rkt"
+         )
+(provide add-move-set-to-map
+         union-move-set-maps
+         )
+
+(define-metafunction formality-body
+  ;; Updates the move-set-map so that the paths in `MoveSet` are considered moved on entry to
+  ;; `BasicBlockIds` (in addition to whatever paths were already considered moved).
+  union-move-set-maps : MoveSetMap_0 MoveSetMap_1 -> MoveSetMap
+
+  [(union-move-set-maps MoveSetMap_0 [])
+   MoveSetMap_0
+   ]
+
+  [(union-move-set-maps MoveSetMap_0 [(BasicBlockId_0 MoveSet_0) (BasicBlockId_1 MoveSet_1) ...])
+   (union-move-set-maps MoveSetMap_1 [(BasicBlockId_1 MoveSet_1) ...])
+   (where/error MoveSetMap_1 (add-move-set-to-map-1 MoveSetMap_0 BasicBlockId_0 MoveSet_0))
+   ]
+  )
+
+(define-metafunction formality-body
+  ;; Updates the move-set-map so that the paths in `MoveSet` are considered moved on entry to
+  ;; `BasicBlockIds` (in addition to whatever paths were already considered moved).
+  add-move-set-to-map : MoveSetMap BasicBlockIds MoveSet -> MoveSetMap
+
+  [(add-move-set-to-map MoveSetMap [] MoveSet_new)
+   MoveSetMap
+   ]
+
+  [(add-move-set-to-map MoveSetMap [BasicBlockId_0 BasicBlockId_1 ...] MoveSet_new)
+   (add-move-set-to-map MoveSetMap_1 [BasicBlockId_1 ...] MoveSet_new)
+   (where/error MoveSetMap_1 (add-move-set-to-map-1 MoveSetMap BasicBlockId_0 MoveSet_new))
+   ]
+  )
+
+(define-metafunction formality-body
+  ;; Helper for the above that permits only a single basic block
+  add-move-set-to-map-1 : MoveSetMap BasicBlockId MoveSet -> MoveSetMap
+
+  [(add-move-set-to-map-1 MoveSetMap BasicBlockId MoveSet_new)
+   [(BasicBlockId_0 MoveSet_0) ... (BasicBlockId MoveSet_u) (BasicBlockId_1 MoveSet_1) ...]
+   (where/error [(BasicBlockId_0 MoveSet_0) ... (BasicBlockId MoveSet_old) (BasicBlockId_1 MoveSet_1) ...] MoveSetMap)
+   (where/error MoveSet_u (union-move-sets MoveSet_old MoveSet_new))
+   ]
+  )

--- a/src/body/borrow-check/move-set.rkt
+++ b/src/body/borrow-check/move-set.rkt
@@ -1,0 +1,81 @@
+#lang racket
+(require redex/reduction-semantics
+         "../../logic/env.rkt"
+         "../grammar.rkt"
+         "places.rkt"
+         )
+(provide initial-move-set
+         add-moved-place
+         add-initialized-place
+         union-move-sets
+         place-is-fully-initialized?
+         place-is-fully-moved?
+         )
+
+(define-metafunction formality-body
+  ;; Creates a move set where all local variables are moved
+  ;; (except for the arguments).
+  initial-move-set : Γ -> MoveSet
+
+  [(initial-move-set Γ)
+   [LocalId_ret LocalId_other ...]
+   (where/error [Ty_arg ..._arg] (argument-types-of-Γ Γ))
+   (where/error [LocalDecl_ret LocalDecl_arg ..._arg LocalDecl_other ...] (local-decls-of-Γ Γ))
+   (where/error (LocalId_ret _ _) LocalDecl_ret)
+   (where/error [(LocalId_other _ _) ...] [LocalDecl_other ...])
+   ]
+  )
+
+(define-metafunction formality-body
+  ;; Union two move-sets.
+  union-move-sets : MoveSet_0 MoveSet_1 -> MoveSet
+
+  [(union-move-sets MoveSet_0 [])
+   MoveSet_0
+   ]
+
+  [(union-move-sets MoveSet_0 [Place_0 Place_1 ...])
+   (union-move-sets MoveSet_1 [Place_1 ...])
+   (where/error MoveSet_1 (add-moved-place MoveSet_0 Place_0))
+   ]
+
+  )
+
+(define-metafunction formality-body
+  ;; Adjusts the move-set to account for `Place` having been moved
+  ;; (i.e., adds `Place` to the set).
+  ;;
+  ;; If `Place` is already in the set, has no effect.
+  add-moved-place : MoveSet Place -> MoveSet
+
+  [(add-moved-place MoveSet Place)
+   (place-set-add MoveSet Place)
+   ]
+  )
+
+(define-metafunction formality-body
+  ;; Adjusts the move-set to account for `Place` having been initialized
+  ;; (i.e., removes `Place` from the set).
+  ;;
+  ;; If `Place` is not in the set, has no effect.
+  add-initialized-place : MoveSet Place -> MoveSet
+
+  [(add-initialized-place MoveSet Place)
+   (place-set-remove-any-suffix MoveSet Place)]
+  )
+
+(define-metafunction formality-body
+  place-is-fully-initialized? : MoveSet Place -> boolean
+
+  [(place-is-fully-initialized? MoveSet Place)
+   (not? (place-set-contains-intersecting-place? MoveSet Place))
+   ]
+  )
+
+(define-metafunction formality-body
+  place-is-fully-moved? : MoveSet Place -> boolean
+
+  [(place-is-fully-moved? MoveSet Place)
+   (place-set-contains-prefix-of? MoveSet Place)
+   ]
+  )

--- a/src/body/borrow-check/places.rkt
+++ b/src/body/borrow-check/places.rkt
@@ -1,0 +1,103 @@
+#lang racket
+(require redex/reduction-semantics
+         "../grammar.rkt"
+         )
+(provide
+ )
+
+(define-metafunction formality-body
+  ;; Adds a place to a place set; if the place, or some more general place, is already present,
+  ;; then returns the set without any changes.
+  ;;
+  ;; Examples:
+  ;;
+  ;; 1. `{x} + y = {x, y}`
+  ;; 2. `{x, y} + y = {x, y}`
+  ;; 3. `{x, y.f1, y.f2} + y = {x, y}`
+  ;; 4. `{x, y} + y.f1 + y.f2 = {x, y}`
+  place-set-add : Places Place -> Places
+
+  [; If `Place` is already in the set, or something in the set is a prefix of `Place`,
+   ; return `Places` without any changes (e.g., cases 2 and 4 above).
+   (place-set-add Places Place_new)
+   Places
+   (where [_ ... Place_old _ ...] Places)
+   (where #t (place-is-prefix-of? Place_old Place_new))
+   ]
+
+  [; If `Place` is already in the set, or something in the set is a prefix of `Place`,
+   ; return `Places` without any changes (e.g., cases 2 and 4 above).
+   (place-set-add Places Place_new)
+   [Place_old1 ... ... Place_new]
+   (where [Place_old ...] Places)
+   (where [[Place_old1 ...] ...] [(place-if-not-prefixed-by Place_old Place_new) ...])
+   ]
+  )
+
+(define-metafunction formality-body
+  ;; If `Place_1` is not prefixed by `Place_2`, return `[Place_1]`.
+  ;; Otherwise, returns `[]`.
+  place-if-not-prefixed-by : Place Place -> [Place ...]
+
+  [(place-if-not-prefixed-by Place_1 Place_2)
+   [Place_1]
+   (where #f (place-is-prefix-of? Place_2 Place_1))]
+
+  [(place-if-not-prefixed-by Place_1 Place_2)
+   []
+   (where #t (place-is-prefix-of? Place_2 Place_1))]
+
+  )
+
+(define-metafunction formality-body
+  ;; Adds a place to a place set; if the place, or some more general place, is already present,
+  ;; then returns the set without any changes.
+  ;;
+  ;; Examples:
+  ;;
+  ;; * `{x} + y = {x, y}`
+  ;; * `{x, y} + y = {x, y}`
+  ;; * `{x, y.f1, y.f2} + y = {x, y}`
+  ;; * `{x, y} + y.f1 + y.f2 = {x, y}`
+  place-is-prefix-of? : Place_0 Place_1 -> boolean
+
+  [(place-is-prefix-of? Place Place) #t]
+
+  [(place-is-prefix-of? Place LocalId) #f]
+
+  [(place-is-prefix-of? Place (* Place_1))
+   (place-is-prefix-of? Place Place_1)
+   ]
+
+  [(place-is-prefix-of? Place (field Place_1 _))
+   (place-is-prefix-of? Place Place_1)
+   ]
+
+  [(place-is-prefix-of? Place (index Place_1 _))
+   (place-is-prefix-of? Place Place_1)
+   ]
+
+  [(place-is-prefix-of? Place (downcast Place_1 _))
+   (place-is-prefix-of? Place Place_1)
+   ]
+  )
+
+(module+ test
+
+  (test-equal
+   (term (place-set-add [x] x))
+   (term [x]))
+
+  (test-equal
+   (term (place-set-add [x y] x))
+   (term [x y]))
+
+  (test-equal
+   (term (place-set-add [x (field y f1) (field y f2)] y))
+   (term [x y]))
+
+  (test-equal
+   (term (place-set-add [x y] (field x f1)))
+   (term [x y]))
+
+  )

--- a/src/body/grammar.rkt
+++ b/src/body/grammar.rkt
@@ -68,6 +68,7 @@
 
   (Constant ::= number)
 
+  (Places ::= [Place ...])
   (Place ::=
          LocalId
          (* Place)

--- a/src/body/grammar.rkt
+++ b/src/body/grammar.rkt
@@ -61,10 +61,11 @@
 
   ;; An `Operand` is the argument to an rvalue.
   (Operand ::=
-           (copy Place)
-           (move Place)
+           (CopyMove Place)
            (const Constant)
            )
+
+  (CopyMove ::= copy move)
 
   (Constant ::= number)
 
@@ -144,6 +145,16 @@
   (GoalAtLocations ::= (GoalAtLocation ...))
   (GoalAtLocation ::= (Location Goal))
 
+  ;; A move set stores a set of places that are moved
+  (MoveSet ::= Places)
+
+  ;; Maps from a basic block to a moveset on entry to that block.
+  (MoveSetMap ::= [(BasicBlockId MoveSet) ...])
+
+  ;; The move-sets before each statement in a block, along with the final move-set
+  ;; (the state before the terminator is executed).
+  (MoveSetsForStatements ::= ([(MoveSet Statement) ...] MoveSet))
+
   ; identifiers of various kinds:
   (MirId BasicBlockId LocalId ::= variable-not-otherwise-mentioned)
   )
@@ -175,12 +186,39 @@
   )
 
 (define-metafunction formality-body
+  ;; Returns the types of the fn arguments from the environment Γ
+  argument-types-of-Γ : Γ -> Tys
+
+  [(argument-types-of-Γ Γ)
+   Tys
+   (where/error (_ _ (Tys -> Ty where Biformulas) _) Γ)]
+  )
+
+(define-metafunction formality-body
+  ;; Returns  the fn return type from the environment Γ
+  return-type-of-Γ : Γ -> Tys
+
+  [(return-type-of-Γ Γ)
+   Ty
+   (where/error (_ _ (Tys -> Ty where Biformulas) _) Γ)]
+  )
+
+(define-metafunction formality-body
   ;; Returns the `LocalDecls` from the MIR body of the environment Γ
   basic-block-decls-of-Γ : Γ -> BasicBlockDecls
 
   [(basic-block-decls-of-Γ Γ)
    BasicBlockDecls
    (where/error (_ BasicBlockDecls) (locals-and-blocks-of-Γ Γ))]
+  )
+
+(define-metafunction formality-body
+  ;; Returns the `LocalDecls` from the MIR body of the environment Γ
+  entry-basic-block-id-of-Γ : Γ -> BasicBlockId
+
+  [(entry-basic-block-id-of-Γ Γ)
+   BasicBlockId_entry
+   (where/error [(BasicBlockId_entry _) BasicBlockDecl ...] (basic-block-decls-of-Γ Γ))]
   )
 
 (define-metafunction formality-body

--- a/src/body/type-of.rkt
+++ b/src/body/type-of.rkt
@@ -1,6 +1,7 @@
 #lang racket
 (require redex/reduction-semantics
          "../logic/substitution.rkt"
+         "../ty/user-ty.rkt"
          "grammar.rkt"
          )
 (provide type-of/Place

--- a/src/rust/test/borrowck-initialization--access-uninit-var.rkt
+++ b/src/rust/test/borrowck-initialization--access-uninit-var.rkt
@@ -1,0 +1,60 @@
+#lang racket
+(require redex/reduction-semantics
+         "../../util.rkt"
+         "../../ty/user-ty.rkt"
+         "../grammar.rkt"
+         "../prove.rkt"
+         )
+
+(module+ test
+  ;; Program:
+  ;;
+  ;; fn foo() -> i32 {
+  ;;     let x: i32;
+  ;;     x
+  ;; }
+  (traced '()
+          (test-equal
+           #f
+           (term (rust:is-core-crate-ok
+                  [(fn foo[] () -> i32
+                       where []
+                       { ∃ [] ([(_0 (user-ty i32) mut)
+                                (_1 (user-ty i32) ())
+                                ]
+
+                               [(bb0 { [(_0 = (use (copy _1))) ; _0 = _1
+                                        ]
+                                       return
+                                       })
+                                ]
+                               )
+                           })
+                   ]))))
+
+  ;; Program:
+  ;;
+  ;; fn foo() -> i32 {
+  ;;     let x: i32 = 22;
+  ;;     x
+  ;; }
+  (traced '()
+          (test-equal
+           #t
+           (term (rust:is-core-crate-ok
+                  [(fn foo[] () -> i32
+                       where []
+                       { ∃ [] ([(_0 (user-ty i32) mut)
+                                (_1 (user-ty i32) ())
+                                ]
+
+                               [(bb0 { [(_1 = (use (const 22)))
+                                        (_0 = (use (copy _1))) ; _0 = _1
+                                        ]
+                                       return
+                                       })
+                                ]
+                               )
+                           })
+                   ]))))
+  )


### PR DESCRIPTION
This extends the borrow check to check for initialized and uninitialized variables. The code is "first draft" and rather minimally tested. I should probably push a few more tests before we land it.

Fixes https://github.com/nikomatsakis/a-mir-formality/issues/84