### PR TITLE
Add missing definition of Operands

### DIFF
--- a/src/body/grammar.rkt
+++ b/src/body/grammar.rkt
@@ -60,6 +60,7 @@
              )
 
   ;; An `Operand` is the argument to an rvalue.
+  (Operands ::= [Operand ...])
   (Operand ::=
            (CopyMove Place)
            (const Constant)


### PR DESCRIPTION
The nonterminal `Operands` is used (e.g. in `call`) but was not actually defined in the grammar.