### PR TITLE
Evaluate generated racket programs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,22 @@
-use rustc_formality;
-use std::env;
+use rustc_formality::{self, OutputFormat};
+use std::{env, process::ExitCode};
 
-fn main() {
+fn main() -> ExitCode {
     // the path to the Rust source file is specified as an argument to the program
     let args = env::args().skip(1).collect::<Vec<_>>();
+    let expect_failure = args.iter().any(|s| s == "--fail");
     let input_path = args
         .iter()
         .find(|arg| !arg.starts_with("--"))
         .expect("Specify input path");
 
-    println!("{}", rustc_formality::run(input_path));
+    let generated_code =
+        rustc_formality::run_rustc(input_path, OutputFormat::Expression, expect_failure)
+            .expect("Failed to run rustc");
+
+    if rustc_formality::run_racket(&generated_code).expect("Failed to run racket") {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    }
 }

--- a/tests/input/issue25860.rkt
+++ b/tests/input/issue25860.rkt
@@ -171,6 +171,6 @@
 }))})] issue25860)))
     ]
 
-   (test-equal #t (term (rust:is-program-ok Rust/Program)))
+   (test-equal #f (term (rust:is-program-ok Rust/Program)))
    )
   )


### PR DESCRIPTION
This allows running `cargo run path/to/input.rs` to translate the given program to racket and evaluate the result. The execution is successful if there is no output on stderr when running racket.