### PR TITLE
Expand body grammar

### DIFF
--- a/racket-src/body/grammar.rkt
+++ b/racket-src/body/grammar.rkt
@@ -75,7 +75,14 @@
 
   (CopyMove ::= copy move)
 
-  (Constant ::= number)
+  (Constant ::=
+            number
+            true
+            false
+            (fn-ptr FnId Parameters)
+            (static StaticId)
+            (tuple (Constant ...))
+            )
 
   (Places ::= [Place ...])
   (Place ::=
@@ -178,16 +185,6 @@
   ; identifiers of various kinds:
   (LocalIds ::= [LocalId ...])
   (MirId BasicBlockId LocalId ::= variable-not-otherwise-mentioned)
-  )
-
-
-(define-metafunction formality-body
-  ;; Returns the `AdtContents` of the ADT with the given `AdtId`.
-  decl-of-adt : Γ AdtId -> AdtDecl
-
-  [(decl-of-adt Γ AdtId)
-   (adt-with-id (crate-decls-of-Γ CrateDecls) AdtId)
-   ]
   )
 
 (define-metafunction formality-body

--- a/racket-src/body/grammar.rkt
+++ b/racket-src/body/grammar.rkt
@@ -40,6 +40,7 @@
           (len Place)
           (BinaryOp Operand Operand)
           (AggregateKind Operands)
+          (cast Operand as Ty)
           unknown-rvalue
           )
 

--- a/racket-src/body/grammar.rkt
+++ b/racket-src/body/grammar.rkt
@@ -39,10 +39,16 @@
           (addr-of MaybeMut Place)
           (len Place)
           (BinaryOp Operand Operand)
+          (AggregateKind Operands)
           unknown-rvalue
           )
 
   (BinaryOp ::= + - * /)
+
+  (AggregateKind ::=
+                 tuple
+                 (adt AdtId VariantId Parameters)
+                 )
 
   ;; A `Terminator` ends a basic block and branches to other blocks.
   (Terminator ::=

--- a/racket-src/body/type-check-goal.rkt
+++ b/racket-src/body/type-check-goal.rkt
@@ -74,10 +74,11 @@
   [(type-of/Place Γ Place Ty_place)
    (type-of/Rvalue Γ Rvalue Ty_rvalue)
    #;(mutability/Place Γ Place mut)
+   (type-check-goal/Rvalue Γ Rvalue Goal_rvalue)
    ----------------------------------------
    (type-check-goal/Statement Γ
                               (Place = Rvalue)
-                              (Ty_rvalue <= Ty_place))
+                              (&& (Goal_rvalue (Ty_rvalue <= Ty_place))))
    ]
 
   )
@@ -117,6 +118,25 @@
                                     ))))
    ----------------------------------------
    (type-check-goal/Terminator Γ (call Operand_fn (Operand_arg ...) Place_dest TargetIds) Goal)
+   ]
+
+  )
+
+(define-judgment-form
+  formality-body
+  #:mode (type-check-goal/Rvalue I I O)
+  #:contract (type-check-goal/Rvalue Γ Rvalue Goal)
+
+  [(type-of/Operands Γ Operands (Ty_op ...))
+   (field-tys Γ AdtId Parameters VariantId ((_ Ty_field) ...))
+   ----------------------------------------
+   (type-check-goal/Rvalue Γ
+                           ((adt AdtId VariantId Parameters) Operands)
+                           (&& ((Ty_op <= Ty_field) ...)))
+   ]
+
+  [----------------------------------------
+   (type-check-goal/Rvalue Γ _ true-goal)
    ]
 
   )

--- a/racket-src/body/type-of.rkt
+++ b/racket-src/body/type-of.rkt
@@ -225,6 +225,11 @@
    ------------------------------------------
    (type-of/Rvalue Γ ((adt AdtId VariantId Parameters) Operands) Ty_adt)
    ]
+
+  [; cast
+   ------------------------------------------
+   (type-of/Rvalue Γ (cast _ as Ty) Ty)
+   ]
   )
 
 (define-metafunction formality-body

--- a/racket-src/body/type-of.rkt
+++ b/racket-src/body/type-of.rkt
@@ -43,7 +43,7 @@
    ]
 
   [; field of a struct
-   ;s
+   ;
    ; extract the name of the singular variant
    (place-type-of Γ Place (rigid-ty AdtId Parameters) ())
    (where (struct AdtId _ where _ ((VariantId _))) (find-adt Γ AdtId))
@@ -125,14 +125,16 @@
    (type-of/Constant Γ false (user-ty bool))]
 
   [; function
-   (where/error (fn _ (KindedVarId ..._n _ ...) (Ty_arg ...) -> Ty_ret _ _ _) (find-fn Γ FnId))
-   (where/error Substitution (create-substitution (KindedVarId ...) (Parameter ...)))
+   (where/error (fn _ KindedVarIds (Ty_arg ...) -> Ty_ret _ _ _) (find-fn Γ FnId))
+   (where/error (KindedVarId_subst ..._n KindedVarId_other ...) KindedVarIds)
+   (where/error Substitution (create-substitution (KindedVarId_subst ...) (Parameter ...)))
    (where/error (Ty_argsubst ...) ((apply-substitution Substitution Ty_arg) ...))
    (where/error Ty_retsubst (apply-substitution Substitution Ty_ret))
    (where/error number_args ,(length (term (Ty_arg ...))))
    (where/error Ty_fnptr (rigid-ty (fn-ptr "Rust" number_args) (Ty_argsubst ... Ty_retsubst)))
+   (where/error Ty (∀ (KindedVarId_other ...) Ty_fnptr))
    ------------------------------------------
-   (type-of/Constant Γ (fn-ptr FnId (Parameter ..._n)) Ty_fnptr)]
+   (type-of/Constant Γ (fn-ptr FnId (Parameter ..._n)) Ty)]
 
   [; static
    (where/error (static _ _ _ _ : Ty = _) (find-static Γ StaticId))

--- a/racket-src/body/well-formed-mir.rkt
+++ b/racket-src/body/well-formed-mir.rkt
@@ -145,6 +145,11 @@
    (well-formed/Rvalue Γ (BinaryOp Operand_rhs Operand_lhs))
    ]
 
+  [(well-formed/Operand Γ Operand) ...
+   ----------------------------------------
+   (well-formed/Rvalue Γ (AggregateKind (Operand ...)))
+   ]
+
   )
 
 (define-judgment-form

--- a/racket-src/body/well-formed-mir.rkt
+++ b/racket-src/body/well-formed-mir.rkt
@@ -167,8 +167,9 @@
    (well-formed/Operand Γ (move Place))
    ]
 
-  [----------------------------------------
-   (well-formed/Operand Γ (const number))
+  [;; FIXME: check const well formedness
+   ----------------------------------------
+   (well-formed/Operand Γ (const Constant))
    ]
 
   )

--- a/racket-src/decl/grammar.rkt
+++ b/racket-src/decl/grammar.rkt
@@ -8,6 +8,8 @@
          trait-decl-id
          trait-with-id
          adt-with-id
+         fn-with-id
+         static-with-id
          crate-decls
          instantiate-bounds-clause
          crate-defining-trait-with-id
@@ -228,5 +230,31 @@
 
   [(instantiate-bounds-clause (: (ParameterKind VarId) Biformulas) Parameter)
    (apply-substitution ((VarId Parameter)) Biformulas)
+   ]
+  )
+
+(define-metafunction formality-decl
+  ;; Find the given function amongst all the declared crates.
+  ;;
+  ;; FIXME: search trait items and impl items
+  fn-with-id : CrateDecls FnId -> FnDecl
+
+  [(fn-with-id CrateDecls FnId)
+   (fn FnId KindedVarIds Tys -> Ty where Biformulas FnBody)
+
+   (where (_ ... CrateDecl _ ...) CrateDecls)
+   (where (crate _ (_ ... (fn FnId KindedVarIds Tys -> Ty where Biformulas FnBody) _ ...)) CrateDecl)
+   ]
+  )
+
+(define-metafunction formality-decl
+  ;; Find the given static variable amongst all the declared crates.
+  static-with-id : CrateDecls StaticId -> StaticDecl
+
+  [(static-with-id CrateDecls StaticId)
+   (static StaticId KindedVarIds where Biformulas : Ty = FnBody)
+
+   (where (_ ... CrateDecl _ ...) CrateDecls)
+   (where (crate _ (_ ... (static StaticId KindedVarIds where Biformulas : Ty = FnBody) _ ...)) CrateDecl)
    ]
   )

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -4,6 +4,7 @@ use rustc_span::Symbol;
 
 use crate::OutputFormat;
 
+mod consts;
 mod decl;
 mod mir;
 mod ty;

--- a/src/gen/consts.rs
+++ b/src/gen/consts.rs
@@ -44,7 +44,11 @@ impl<'tcx> FormalityGen<'tcx> {
         let fn_id = self.emit_def_path(def_id);
         let params = substs
             .iter()
-            .map(|arg| self.emit_generic_arg(arg))
+            .map(|arg| match arg.unpack() {
+                ty::subst::GenericArgKind::Lifetime(lt) => self.emit_lifetime(lt),
+                ty::subst::GenericArgKind::Type(ty) => self.emit_ty(ty),
+                ty::subst::GenericArgKind::Const(_) => unimplemented!(),
+            })
             .intersperse(" ".to_string())
             .collect::<String>();
 

--- a/src/gen/consts.rs
+++ b/src/gen/consts.rs
@@ -1,0 +1,107 @@
+use crate::gen::FormalityGen;
+
+use mir::interpret::{ConstValue, Scalar};
+use rustc_const_eval::interpret::GlobalAlloc;
+use rustc_middle::{mir, ty};
+
+impl<'tcx> FormalityGen<'tcx> {
+    fn emit_scalar_int(&self, int: ty::ScalarInt, ty: ty::Ty<'tcx>) -> Option<String> {
+        match ty.kind() {
+            ty::Bool if int == ty::ScalarInt::FALSE => Some("false".to_string()),
+            ty::Bool if int == ty::ScalarInt::TRUE => Some("true".to_string()),
+            ty::Uint(_) | ty::Int(_) => Some(int.to_string()),
+            _ => None,
+        }
+    }
+
+    fn emit_ty_const(&self, ct: ty::Const<'tcx>) -> Option<String> {
+        let ty = ct.ty();
+        match ct.kind() {
+            ty::ConstKind::Value(valtree) => match (valtree, ty.kind()) {
+                (ty::ValTree::Branch(_), ty::Tuple(..)) => {
+                    let contents = self.tcx.destructure_const(ct);
+                    let fields = contents
+                        .fields
+                        .iter()
+                        .flat_map(|field| self.emit_ty_const(*field))
+                        .intersperse(" ".to_string())
+                        .collect::<String>();
+
+                    Some(format!("(tuple [{fields}])"))
+                }
+                (ty::ValTree::Leaf(int), _) => self.emit_scalar_int(int, ty),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    fn emit_const_fn_ptr(
+        &self,
+        def_id: rustc_hir::def_id::DefId,
+        substs: ty::SubstsRef<'tcx>,
+    ) -> String {
+        let fn_id = self.emit_def_path(def_id);
+        let params = substs
+            .iter()
+            .map(|arg| self.emit_generic_arg(arg))
+            .intersperse(" ".to_string())
+            .collect::<String>();
+
+        format!("(fn-ptr {fn_id} [{params}])")
+    }
+
+    fn emit_mir_const(&self, ct: ConstValue<'tcx>, ty: ty::Ty<'tcx>) -> Option<String> {
+        match (ct, ty.kind()) {
+            (_, ty::Tuple(..)) => {
+                let contents = self.tcx.try_destructure_mir_constant(
+                    ty::ParamEnv::reveal_all().and(mir::ConstantKind::Val(ct, ty)),
+                )?;
+
+                let fields = contents
+                    .fields
+                    .iter()
+                    .flat_map(|field| match field {
+                        mir::ConstantKind::Ty(ct) => self.emit_ty_const(*ct),
+                        mir::ConstantKind::Val(ct, ty) => self.emit_mir_const(*ct, *ty),
+                    })
+                    .intersperse(" ".to_string())
+                    .collect::<String>();
+
+                Some(format!("(tuple [{fields}])"))
+            }
+            (ConstValue::Scalar(Scalar::Int(int)), _) => self.emit_scalar_int(int, ty),
+            (ConstValue::Scalar(Scalar::Ptr(ptr, _)), ty::FnPtr(_)) => {
+                let (alloc_id, _) = ptr.into_parts();
+                if let GlobalAlloc::Function(instance) = self.tcx.try_get_global_alloc(alloc_id)? {
+                    Some(self.emit_const_fn_ptr(instance.def_id(), instance.substs))
+                } else {
+                    None
+                }
+            }
+            (ConstValue::Scalar(Scalar::Ptr(ptr, _)), _) => {
+                let (alloc_id, _) = ptr.into_parts();
+                if let GlobalAlloc::Static(def_id) = self.tcx.try_get_global_alloc(alloc_id)? {
+                    Some(format!("(static {})", self.emit_def_path(def_id)))
+                } else {
+                    None
+                }
+            }
+            (ConstValue::ZeroSized, ty::FnDef(def_id, substs)) => {
+                Some(self.emit_const_fn_ptr(*def_id, *substs))
+            }
+            _ => None,
+        }
+    }
+
+    pub fn emit_const(&self, constant: mir::Constant<'tcx>) -> String {
+        match constant.literal {
+            mir::ConstantKind::Ty(ct) => self.emit_ty_const(ct),
+            mir::ConstantKind::Val(ct, ty) => self.emit_mir_const(ct, ty),
+        }
+        .unwrap_or_else(|| {
+            eprintln!("unknown const: {constant:?}");
+            "unknown-const".to_string()
+        })
+    }
+}

--- a/src/gen/consts.rs
+++ b/src/gen/consts.rs
@@ -44,11 +44,7 @@ impl<'tcx> FormalityGen<'tcx> {
         let fn_id = self.emit_def_path(def_id);
         let params = substs
             .iter()
-            .map(|arg| match arg.unpack() {
-                ty::subst::GenericArgKind::Lifetime(lt) => self.emit_lifetime(lt),
-                ty::subst::GenericArgKind::Type(ty) => self.emit_ty(ty),
-                ty::subst::GenericArgKind::Const(_) => unimplemented!(),
-            })
+            .map(|arg| self.emit_param(arg))
             .intersperse(" ".to_string())
             .collect::<String>();
 

--- a/src/gen/decl.rs
+++ b/src/gen/decl.rs
@@ -172,7 +172,7 @@ impl<'tcx> FormalityGen<'tcx> {
             .substs
             .iter()
             .skip(1) // skip self type
-            .map(|arg| self.emit_generic_arg(arg))
+            .map(|arg| self.emit_user_param(arg))
             .intersperse(" ".to_string())
             .collect::<String>();
 

--- a/src/gen/mir.rs
+++ b/src/gen/mir.rs
@@ -83,7 +83,7 @@ impl<'tcx> FormalityGen<'tcx> {
                         let variant = variant_index.index();
                         let params = substs
                             .iter()
-                            .map(|arg| self.emit_generic_arg(arg))
+                            .map(|arg| self.emit_param(arg))
                             .intersperse(" ".to_string())
                             .collect::<String>();
 

--- a/src/gen/ty.rs
+++ b/src/gen/ty.rs
@@ -13,7 +13,7 @@ impl<'tcx> FormalityGen<'tcx> {
                     .substs
                     .iter()
                     .skip(1) // skip the self type
-                    .map(|arg| self.emit_generic_arg(arg))
+                    .map(|arg| self.emit_user_param(arg))
                     .intersperse(" ".to_string())
                     .collect::<String>();
 
@@ -79,7 +79,7 @@ impl<'tcx> FormalityGen<'tcx> {
                 let def_path = self.emit_def_path(adt_def.did());
                 let substs_str = substs
                     .iter()
-                    .map(|arg| self.emit_generic_arg(arg))
+                    .map(|arg| self.emit_user_param(arg))
                     .intersperse(" ".to_string())
                     .collect::<String>();
 
@@ -155,7 +155,7 @@ impl<'tcx> FormalityGen<'tcx> {
             .iter()
             .take(trait_generics.count())
             .skip(1) // skip self type
-            .map(|arg| self.emit_generic_arg(arg))
+            .map(|arg| self.emit_user_param(arg))
             .intersperse(" ".to_string())
             .collect::<String>();
 
@@ -163,7 +163,7 @@ impl<'tcx> FormalityGen<'tcx> {
             .substs
             .iter()
             .skip(trait_generics.count())
-            .map(|arg| self.emit_generic_arg(arg))
+            .map(|arg| self.emit_user_param(arg))
             .intersperse(" ".to_string())
             .collect::<String>();
 
@@ -190,10 +190,18 @@ impl<'tcx> FormalityGen<'tcx> {
         }
     }
 
-    pub fn emit_generic_arg(&self, generic_arg: ty::subst::GenericArg<'tcx>) -> String {
+    pub fn emit_user_param(&self, generic_arg: ty::subst::GenericArg<'tcx>) -> String {
         match generic_arg.unpack() {
             ty::subst::GenericArgKind::Lifetime(lt) => self.emit_lifetime(lt),
             ty::subst::GenericArgKind::Type(ty) => self.emit_user_ty(ty),
+            ty::subst::GenericArgKind::Const(_) => unimplemented!(),
+        }
+    }
+
+    pub fn emit_param(&self, generic_arg: ty::subst::GenericArg<'tcx>) -> String {
+        match generic_arg.unpack() {
+            ty::subst::GenericArgKind::Lifetime(lt) => self.emit_lifetime(lt),
+            ty::subst::GenericArgKind::Type(ty) => self.emit_ty(ty),
             ty::subst::GenericArgKind::Const(_) => unimplemented!(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 // rustup component add rustc-dev llvm-tools-preview
 // version: rustc 1.65.0-nightly (29e4a9ee0 2022-08-10)
 
+extern crate rustc_const_eval;
 extern crate rustc_error_codes;
 extern crate rustc_errors;
 extern crate rustc_hash;

--- a/tests/input/issue25860.rkt
+++ b/tests/input/issue25860.rkt
@@ -153,7 +153,7 @@
       (storage-live _4)
       (_4 = (ref ?0 () _2))
       (_3 = (ref ?1 () (* _4)))]
-     (call (const (fn-ptr bad [i32]))[(move _3)] _1 (bb1))
+     (call (const (fn-ptr bad [(mf-apply user-ty i32)]))[(move _3)] _1 (bb1))
    })
    (bb1 {
      [(storage-dead _3)

--- a/tests/input/issue25860.rkt
+++ b/tests/input/issue25860.rkt
@@ -36,7 +36,7 @@
      [(storage-live _1)
       (storage-live _2)
       (storage-live _3)
-      (_3 = (tuple ()))
+      (_3 = (tuple []))
       (_2 = (ref ?0 () _3))
       (_1 = (ref ?1 () _2))
       (_0 = (ref ?2 () (* _1)))
@@ -104,14 +104,14 @@
 
   [(bb0 {
      [(storage-live _2)
-      (_2 = unknown-rvalue)
+      (_2 = (cast (const (fn-ptr foo [T])) as (mf-apply user-ty (for[(lifetime %a) (lifetime %b)] (fn ((& %a (& %b ())) (& %b T)) -> (& %a T))))))
       noop
       noop
       (storage-live _3)
       (_3 = (use (copy _2)))
       (storage-live _4)
       (storage-live _5)
-      (_5 = (use (const 0)))
+      (_5 = (use (const (static UNIT))))
       (_4 = (ref ?3 () (* (* _5))))
       (storage-live _6)
       (_6 = (use (copy _1)))]
@@ -153,14 +153,14 @@
       (storage-live _4)
       (_4 = (ref ?0 () _2))
       (_3 = (ref ?1 () (* _4)))]
-     (call (const 0)[(move _3)] _1 (bb1))
+     (call (const (fn-ptr bad [i32]))[(move _3)] _1 (bb1))
    })
    (bb1 {
      [(storage-dead _3)
       (storage-dead _2)
       noop
       (storage-dead _4)
-      (_0 = (use (const 0)))
+      (_0 = (use (const (tuple []))))
       (storage-dead _1)]
      return
    })

--- a/tests/input/issue25860.rkt
+++ b/tests/input/issue25860.rkt
@@ -36,7 +36,7 @@
      [(storage-live _1)
       (storage-live _2)
       (storage-live _3)
-      (_3 = unknown-rvalue)
+      (_3 = (tuple ()))
       (_2 = (ref ?0 () _3))
       (_1 = (ref ?1 () _2))
       (_0 = (ref ?2 () (* _1)))


### PR DESCRIPTION
This PR expands the body grammar, adding aggregate and cast rvalue variants as well as supporting more constant values. Besides the racket definitions, the formality generator was adapted as well. As a result, the issue25860 example can now be fully translated. The well-formedness and type checking of the new constructs is not yet fully implemented. Also, I want to add some more tests.