### PR TITLE
Type-check function calls and reification casts

### DIFF
--- a/racket-src/body/type-check-goal.rkt
+++ b/racket-src/body/type-check-goal.rkt
@@ -140,10 +140,11 @@
    (fn-ty-signature Γ Ty_fn (∀ KindedVarIds (implies Biformulas ((Ty_arg ...) -> Ty_ret))))
    (where/error number_args ,(length (term (Ty_arg ...))))
    (where/error Ty_fnptr (rigid-ty (fn-ptr "Rust" number_args) (Ty_arg ... Ty_ret)))
+   (where/error Ty_reified (∀ KindedVarIds (implies Biformulas Ty_fnptr)))
    ----------------------------------------
    (type-check-goal/Rvalue Γ
                            (cast Operand as Ty_target)
-                           (∀ KindedVarIds (implies Biformulas (Ty_fnptr <= Ty_target))))
+                           (Ty_reified <= Ty_target))
    ]
 
   [----------------------------------------
@@ -157,18 +158,18 @@
   #:mode (fn-ty-signature I I O)
   #:contract (fn-ty-signature Γ Ty Signature)
 
-  [(fn-ty-signature Γ Ty (∀ () (implies Biformulas (Tys_args -> Ty_ret))))
+  [(fn-ty-signature Γ Ty (∀ [KindedVarId_2 ...] (implies Biformulas (Tys_args -> Ty_ret))))
    ----------------------------------------
    (fn-ty-signature Γ
-                    (∀ KindedVarIds Ty)
-                    (∀ KindedVarIds (implies Biformulas (Tys_args -> Ty_ret))))
+                    (∀ [KindedVarId_1 ...] Ty)
+                    (∀ [KindedVarId_1 ... KindedVarId_2 ...] (implies Biformulas (Tys_args -> Ty_ret))))
    ]
 
-  [(fn-ty-signature Γ Ty (∀ () (implies () (Tys_args -> Ty_ret))))
+  [(fn-ty-signature Γ Ty (∀ () (implies [Biformula_2 ...] (Tys_args -> Ty_ret))))
    ----------------------------------------
    (fn-ty-signature Γ
-                    (implies Biformulas Ty)
-                    (∀ () (implies Biformulas (Tys_args -> Ty_ret))))
+                    (implies [Biformula_1 ...] Ty)
+                    (∀ () (implies [Biformula_1 ... Biformula_2 ...] (Tys_args -> Ty_ret))))
    ]
 
   [----------------------------------------

--- a/racket-src/body/type-check-goal.rkt
+++ b/racket-src/body/type-check-goal.rkt
@@ -157,10 +157,24 @@
   #:mode (fn-ty-signature I I O)
   #:contract (fn-ty-signature Γ Ty Signature)
 
+  [(fn-ty-signature Γ Ty (∀ () (implies Biformulas (Tys_args -> Ty_ret))))
+   ----------------------------------------
+   (fn-ty-signature Γ
+                    (∀ KindedVarIds Ty)
+                    (∀ KindedVarIds (implies Biformulas (Tys_args -> Ty_ret))))
+   ]
+
+  [(fn-ty-signature Γ Ty (∀ () (implies () (Tys_args -> Ty_ret))))
+   ----------------------------------------
+   (fn-ty-signature Γ
+                    (implies Biformulas Ty)
+                    (∀ () (implies Biformulas (Tys_args -> Ty_ret))))
+   ]
+
   [----------------------------------------
    (fn-ty-signature Γ
-                    (∀ KindedVarIds (implies Biformulas (rigid-ty (fn-ptr _ _) (Ty_arg ... Ty_ret))))
-                    (∀ KindedVarIds (implies Biformulas ((Ty_arg ...) -> Ty_ret))))
+                    (rigid-ty (fn-ptr _ _) (Ty_arg ... Ty_ret))
+                    (∀ () (implies () ((Ty_arg ...) -> Ty_ret))))
    ]
 
   [(where/error (fn _ KindedVarIds_fn (Ty_arg ...) -> Ty_ret _ _ _) (find-fn Γ FnId))
@@ -169,8 +183,8 @@
    (where/error Ty_retsubst (apply-substitution Substitution Ty_ret))
    ----------------------------------------
    (fn-ty-signature Γ
-                    (∀ KindedVarIds (implies Biformulas (rigid-ty (fn-def FnId) Parameters)))
-                    (∀ KindedVarIds (implies Biformulas ((Ty_argsubst ...) -> Ty_retsubst))))
+                    (rigid-ty (fn-def FnId) Parameters)
+                    (∀ () (implies () ((Ty_argsubst ...) -> Ty_retsubst))))
    ]
 
   )

--- a/racket-src/body/type-check-goal.rkt
+++ b/racket-src/body/type-check-goal.rkt
@@ -111,7 +111,7 @@
   [(type-of/Operand Γ Operand_fn Ty_fn)
    (type-of/Operand Γ Operand_arg Ty_arg) ...
    (type-of/Place Γ Place_dest Ty_dest)
-   (where (∀ KindedVarIds (implies (Biformula ...) ((Ty_formal ...) -> Ty_ret))) (ty-signature Γ Ty_fn))
+   (fn-ty-signature Γ Ty_fn (∀ KindedVarIds (implies (Biformula ...) ((Ty_formal ...) -> Ty_ret))))
    (where Goal (∃ KindedVarIds (&& ((Ty_arg <= Ty_formal) ...
                                     (Ty_ret <= Ty_dest)
                                     Biformula ...
@@ -135,9 +135,43 @@
                            (&& ((Ty_op <= Ty_field) ...)))
    ]
 
+  [; type-check ReifyFnPointer casts
+   (type-of/Operand Γ Operand Ty_fn)
+   (fn-ty-signature Γ Ty_fn (∀ KindedVarIds (implies Biformulas ((Ty_arg ...) -> Ty_ret))))
+   (where/error number_args ,(length (term (Ty_arg ...))))
+   (where/error Ty_fnptr (rigid-ty (fn-ptr "Rust" number_args) (Ty_arg ... Ty_ret)))
+   (where/error Ty_reified (∀ KindedVarIds (implies Biformulas Ty_fnptr)))
+   ----------------------------------------
+   (type-check-goal/Rvalue Γ
+                           (cast Operand as Ty_target)
+                           (&& (Ty_reified <= Ty_target)))
+   ]
+
   [----------------------------------------
    (type-check-goal/Rvalue Γ _ true-goal)
    ]
 
   )
 
+(define-judgment-form
+  formality-body
+  #:mode (fn-ty-signature I I O)
+  #:contract (fn-ty-signature Γ Ty Signature)
+
+  [----------------------------------------
+   (fn-ty-signature Γ
+                    (∀ KindedVarIds (implies Biformulas (rigid-ty (fn-ptr _ _) (Ty_arg ... Ty_ret))))
+                    (∀ KindedVarIds (implies Biformulas ((Ty_arg ...) -> Ty_ret))))
+   ]
+
+  [(where/error (fn _ KindedVarIds_fn (Ty_arg ...) -> Ty_ret _ _ _) (find-fn Γ FnId))
+   (where/error Substitution (create-substitution KindedVarIds_fn Parameters))
+   (where/error (Ty_argsubst ...) ((apply-substitution Substitution Ty_arg) ...))
+   (where/error Ty_retsubst (apply-substitution Substitution Ty_ret))
+   ----------------------------------------
+   (fn-ty-signature Γ
+                    (∀ KindedVarIds (implies Biformulas (rigid-ty (fn-def FnId) Parameters)))
+                    (∀ KindedVarIds (implies Biformulas ((Ty_argsubst ...) -> Ty_retsubst))))
+   ]
+
+  )

--- a/racket-src/body/type-check-goal.rkt
+++ b/racket-src/body/type-check-goal.rkt
@@ -140,11 +140,10 @@
    (fn-ty-signature Γ Ty_fn (∀ KindedVarIds (implies Biformulas ((Ty_arg ...) -> Ty_ret))))
    (where/error number_args ,(length (term (Ty_arg ...))))
    (where/error Ty_fnptr (rigid-ty (fn-ptr "Rust" number_args) (Ty_arg ... Ty_ret)))
-   (where/error Ty_reified (∀ KindedVarIds (implies Biformulas Ty_fnptr)))
    ----------------------------------------
    (type-check-goal/Rvalue Γ
                            (cast Operand as Ty_target)
-                           (&& (Ty_reified <= Ty_target)))
+                           (∀ KindedVarIds (implies Biformulas (Ty_fnptr <= Ty_target))))
    ]
 
   [----------------------------------------

--- a/racket-src/body/type-of.rkt
+++ b/racket-src/body/type-of.rkt
@@ -9,6 +9,7 @@
          type-of/Operands
          type-of/Operand
          field-tys
+         find-fn
          )
 
 ;; type-of judgments:

--- a/racket-src/decl/well-formed/parameter.rkt
+++ b/racket-src/decl/well-formed/parameter.rkt
@@ -122,7 +122,7 @@
    ]
 
   [(well-formed-subgoals-for-ty CrateDecls (rigid-ty (fn-ptr _ _) (Ty ...)))
-   [(well-formed (Type Ty)) ...]
+   [(well-formed (type Ty)) ...]
    ]
 
   [(well-formed-subgoals-for-ty CrateDecls (rigid-ty (ref _) (Lt Ty)))

--- a/racket-src/rust/test/type-check-reify.rkt
+++ b/racket-src/rust/test/type-check-reify.rkt
@@ -1,0 +1,49 @@
+#lang racket
+(require redex/reduction-semantics
+         "../../util.rkt"
+         "../../ty/user-ty.rkt"
+         "../grammar.rkt"
+         "../prove.rkt"
+         )
+
+(module+ test
+  ;; Program:
+  ;;
+  ;; fn foo(x: &()) {}
+  ;; 
+  ;; fn main() {
+  ;;     let f: fn(&'static ()) = foo;
+  ;; }
+  (traced '()
+          (test-equal
+           #f
+           (term (rust:is-core-crate-ok
+                  [(fn foo[(lifetime %a)] ((& %a ())) -> ()
+                       where []
+                       (∃ [(lifetime ?0)] {
+                                           [(_0 (mf-apply user-ty ()) mut)
+                                            (_1 (mf-apply user-ty (& ?0 ())) mut)]
+
+                                           [(bb0 {
+                                                  [(_0 = (use (const (tuple []))))]
+                                                  return
+                                                  })]
+                                           }))
+                   (fn main[] () -> ()
+                       where []
+                       (∃ [(lifetime ?0)
+                           (lifetime ?1)
+                           (lifetime ?2)] {
+                                           [(_0 (mf-apply user-ty ()) mut)
+                                            (_1 (mf-apply user-ty (fn ((& ?0 ())) -> ())) ())]
+
+                                           [(bb0 {
+                                                  [(storage-live _1)
+                                                   (_1 = (cast (const (fn-ptr foo [])) as (mf-apply user-ty (for[(lifetime %a)] (fn ((& %a ())) -> ())))))
+                                                   (_0 = (use (const (tuple []))))
+                                                   (storage-dead _1)]
+                                                  return
+                                                  })]
+                                           }))
+                   ]))))
+  )

--- a/racket-src/ty/grammar.rkt
+++ b/racket-src/ty/grammar.rkt
@@ -197,7 +197,7 @@
   ;; Signature
   ;;
   ;; Callable functions (with any ABI)
-  (Signature ::= (ForAll KindedVarIds (implies Biformulas (Tys_formal -> Ty_ret))))
+  (Signature ::= (∀ KindedVarIds (implies Biformulas (Tys -> Ty))))
 
   ;; Generic parameters
   (Generics ::= (GenericParameters Biformulas))


### PR DESCRIPTION
This implements a function to get the signature from a function type and uses it to type-check function calls and reification casts in MIR. 

closes #100
closes #101 