### PR TITLE
Temporarily switch redex back to 8.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:plt/racket
           sudo apt install xvfb racket
+          sh -c ./revert-redex-changes
       - name: Run Tests
         run: |
           xvfb-run ./test --all
@@ -27,6 +28,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:plt/racket
           sudo apt install xvfb racket
+          sh -c ./revert-redex-changes
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:

--- a/revert-redex-changes
+++ b/revert-redex-changes
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+raco pkg install --force --scope user --catalog https://pkgs.racket-lang.org redex-lib
+git clone -b v8.5 --single-branch --depth 1 https://github.com/racket/redex.git
+cd redex
+raco pkg update redex-lib/


### PR DESCRIPTION
Stopgap workaround. Don't know enough redex to investigate yet, but the tests start failing after this change: https://github.com/racket/redex/commit/3a47c0232593fdddde99ddff6c842f0fb4f347d7