### PR TITLE
Add well-formed-fn predicate

### DIFF
--- a/racket-src/decl/decl-to-clause/crate-item.rkt
+++ b/racket-src/decl/decl-to-clause/crate-item.rkt
@@ -209,24 +209,24 @@
 
   [;; For a function declared in the crate C, like the following:
    ;;
-   ;;     fn foo<'a, T>(&'a T) -> &'a T where T: Ord { ... }
+   ;;     fn foo<T>(x: T) -> T where T: Ord { ... }
    ;;
    ;; We generate the following clauses
    ;;
-   ;;     (∀ ((type T))
-   ;;         (well-formed-fn (foo (T))) :-
+   ;;     (∀ [(type T)]
+   ;;         (well-formed-fn foo[T]) :-
    ;;            (well-formed (type T))
    ;;            (is-implemented (Ord T)))
    ;;
    ;; And the following invariants local to the crate C:
    ;;
-   ;;     (∀ ((type T))
-   ;;         (well-formed (type (foo (T)))) => (is-implemented (Ord T)))
+   ;;     (∀ [(type T)]
+   ;;         (well-formed (type foo[T])) => (is-implemented (Ord T)))
    ;;
    ;; And the following global invariants:
    ;;
-   ;;     (∀ ((type T))
-   ;;         (well-formed (type (foo (T)))) => (well-formed (type T)))
+   ;;     (∀ [(type T)]
+   ;;         (well-formed (type foo[T])) => (well-formed (type T)))
    (crate-item-decl-rules CrateDecls CrateId (fn FnId KindedVarIds _ -> _ where (Biformula ...) _))
    ([Clause_wf-fn] [Invariant_well-formed-where-clause ...
                     Invariant_in-scope-where-clause ...

--- a/racket-src/decl/decl-to-clause/crate-item.rkt
+++ b/racket-src/decl/decl-to-clause/crate-item.rkt
@@ -331,27 +331,3 @@
    )
 
   )
-
-(define-metafunction formality-decl
-  outlives-clauses : Biformulas -> Biformulas
-
-  ((outlives-clauses (Biformula ...))
-   (flatten ((filter-outlives-where-clause Biformula) ...))
-   )
-
-  )
-
-(define-metafunction formality-decl
-  filter-outlives-where-clause : Biformula -> Biformulas
-
-  (; Keep `P1 : P2` bounds
-   (filter-outlives-where-clause (Parameter_1 -outlives- Parameter_2))
-   ((Parameter_1 -outlives- Parameter_2))
-   )
-
-  (; Discard others
-   (filter-outlives-where-clause Biformula)
-   ()
-   )
-
-  )

--- a/racket-src/decl/decl-to-clause/trait-item.rkt
+++ b/racket-src/decl/decl-to-clause/trait-item.rkt
@@ -5,6 +5,7 @@
          "../../logic/env.rkt"
          )
 (provide trait-item-decl-rules
+         outlives-clauses
          )
 
 (define-metafunction formality-decl
@@ -142,4 +143,28 @@
                                     ]
                                    ))
    ]
+  )
+
+(define-metafunction formality-decl
+  outlives-clauses : Biformulas -> Biformulas
+
+  ((outlives-clauses (Biformula ...))
+   (flatten ((filter-outlives-where-clause Biformula) ...))
+   )
+
+  )
+
+(define-metafunction formality-decl
+  filter-outlives-where-clause : Biformula -> Biformulas
+
+  (; Keep `P1 : P2` bounds
+   (filter-outlives-where-clause (Parameter_1 -outlives- Parameter_2))
+   ((Parameter_1 -outlives- Parameter_2))
+   )
+
+  (; Discard others
+   (filter-outlives-where-clause Biformula)
+   ()
+   )
+
   )

--- a/racket-src/decl/well-formed/parameter.rkt
+++ b/racket-src/decl/well-formed/parameter.rkt
@@ -125,6 +125,10 @@
    [(well-formed (Type Ty)) ...]
    ]
 
+  [(well-formed-subgoals-for-ty CrateDecls (rigid-ty (fn-def FnId) Parameters))
+   [(well-formed-fn (rigid-ty (fn-def FnId) Parameters))]
+   ]
+
   [(well-formed-subgoals-for-ty CrateDecls (rigid-ty (ref _) (Lt Ty)))
    [(Ty -outlives- Lt)]
    ]

--- a/racket-src/ty/grammar.rkt
+++ b/racket-src/ty/grammar.rkt
@@ -53,6 +53,8 @@
              (well-formed-adt (rigid-ty AdtId Parameters))
              ; the given alias type is well-formed
              (well-formed-alias (alias-ty AliasName Parameters))
+             ; the given function is well-formed
+             (well-formed-fn (rigid-ty (fn-def FnId) Parameters))
              ; normalize a given alias to another type
              (normalizes-to AliasTy Ty)
              )
@@ -67,6 +69,7 @@
                       (in-scope ParameterKind)
                       (well-formed-adt AdtId)
                       (well-formed-alias AliasName)
+                      (well-formed-fn FnId)
                       (normalizes-to AliasName)
                       )
 

--- a/racket-src/ty/predicate.rkt
+++ b/racket-src/ty/predicate.rkt
@@ -38,6 +38,10 @@
    ((well-formed-alias AliasName) Parameters -> ())
    ]
 
+  [(ty:debone-predicate (well-formed-fn (rigid-ty (fn-def FnId) Parameters)))
+   ((well-formed-fn FnId) Parameters -> ())
+   ]
+
   [(ty:debone-predicate (normalizes-to (alias-ty AliasName (Parameter ...)) Ty))
    ((normalizes-to AliasName) (Parameter ...) -> (Ty))
    ]


### PR DESCRIPTION
Addresses #99. This only adds a way to check that `fn-def` types are well-formed but does check the well-formedness of e.g. function constants.