### PR TITLE
Split CI racket tests according to directories.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  racket-test:
+  racket-test-logic:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -19,7 +19,97 @@ jobs:
           sh -c ./revert-redex-changes
       - name: Run Tests
         run: |
-          xvfb-run ./test --all
+          xvfb-run ./test racket-src/logic racket-src/util.rkt
+  racket-test-ty:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Racket
+        run: |
+          sudo add-apt-repository ppa:plt/racket
+          sudo apt install xvfb racket
+          sh -c ./revert-redex-changes
+      - name: Run Tests
+        run: |
+          xvfb-run ./test racket-src/ty
+  racket-test-decl:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Racket
+        run: |
+          sudo add-apt-repository ppa:plt/racket
+          sudo apt install xvfb racket
+          sh -c ./revert-redex-changes
+      - name: Run Tests
+        run: |
+          xvfb-run ./test racket-src/decl
+  racket-test-body:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Racket
+        run: |
+          sudo add-apt-repository ppa:plt/racket
+          sudo apt install xvfb racket
+          sh -c ./revert-redex-changes
+      - name: Run Tests
+        run: |
+          xvfb-run ./test racket-src/body
+  racket-test-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Racket
+        run: |
+          sudo add-apt-repository ppa:plt/racket
+          sudo apt install xvfb racket
+          sh -c ./revert-redex-changes
+      - name: Run Tests
+        run: |
+          xvfb-run ./test racket-src/check
+  racket-test-rust-a-to-g:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Racket
+        run: |
+          sudo add-apt-repository ppa:plt/racket
+          sudo apt install xvfb racket
+          sh -c ./revert-redex-changes
+      - name: Run Tests
+        run: |
+          rm -rf racket-src/rust/test/{h*,i*,j*,k*,l*,m*,n*,o*,p*,q*}
+          rm -rf racket-src/rust/test/{r*,s*,t*,u*,v*,w*,x*,y*,z*}
+          xvfb-run ./test racket-src/rust
+  racket-test-rust-h-to-q:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Racket
+        run: |
+          sudo add-apt-repository ppa:plt/racket
+          sudo apt install xvfb racket
+          sh -c ./revert-redex-changes
+      - name: Run Tests
+        run: |
+          rm -rf racket-src/rust/test/{a*,b*,c*,d*,e*,f*,g*}
+          rm -rf racket-src/rust/test/{r*,s*,t*,u*,v*,w*,x*,y*,z*}
+          xvfb-run ./test racket-src/rust
+  racket-test-rust-r-to-z:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Racket
+        run: |
+          sudo add-apt-repository ppa:plt/racket
+          sudo apt install xvfb racket
+          sh -c ./revert-redex-changes
+      - name: Run Tests
+        run: |
+          rm -rf racket-src/rust/test/{a*,b*,c*,d*,e*,f*,g*}
+          rm -rf racket-src/rust/test/{h*,i*,j*,k*,l*,m*,n*,o*,p*,q*}
+          xvfb-run ./test racket-src/rust
   rust-test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This reduces CI run duration from `~17m 43s` to `~8m 8s` with more parallelisms. The downside is that if a new module is added beside `logic, ty, decl, body, check, rust` in the future, ci configuration needs to be updated for its tests to run.